### PR TITLE
Allow to use hardlinks in LocalDownload.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.25:
+  Allow to use hardlinks in LocalDownload
 3.0.24:
   Remove debug logs
 3.0.23:

--- a/biomaj_download/download/localcopy.py
+++ b/biomaj_download/download/localcopy.py
@@ -18,10 +18,11 @@ class LocalDownload(DownloadInterface):
 
     '''
 
-    def __init__(self, rootdir):
+    def __init__(self, rootdir, use_hardlinks=False):
         DownloadInterface.__init__(self)
         self.logger.debug('Download')
         self.rootdir = rootdir
+        self.use_hardlinks = use_hardlinks
 
     def download(self, local_dir):
         '''
@@ -32,7 +33,9 @@ class LocalDownload(DownloadInterface):
         :return: list of downloaded files
         '''
         self.logger.debug('Local:Download')
-        Utils.copy_files(self.files_to_download, local_dir, lock=self.mkdir_lock)
+        Utils.copy_files(self.files_to_download, local_dir,
+                         use_hardlinks=self.use_hardlinks,
+                         lock=self.mkdir_lock)
         for rfile in self.files_to_download:
             rfile['download_time'] = 0
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ config = {
     'url': 'http://biomaj.genouest.org',
     'download_url': 'http://biomaj.genouest.org',
     'author_email': 'olivier.sallou@irisa.fr',
-    'version': '3.0.24',
+    'version': '3.0.25',
      'classifiers': [
         # How mature is this project? Common values are
         #   3 - Alpha

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from nose.tools import *
 from nose.plugins.attrib import attr
 

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from nose.tools import *
 from nose.plugins.attrib import attr
 
@@ -239,7 +237,7 @@ class TestBiomajLocalDownload(unittest.TestCase):
       )
     except Exception:
       msg = "In %s: copy worked but hardlinks were not used." % self.id()
-      print(msg, file=sys.stderr)
+      logging.info(msg)
       
 @attr('network')
 @attr('http')


### PR DESCRIPTION
This PR is a follow-up to genouest/biomaj-core#2 to allow `LocalDownload` to use hardlinks. By default, hardlinks are disabled so everything is backward-compatible.