### PR TITLE
Correct weird construct in test.

### DIFF
--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -465,14 +465,9 @@ class TestBiomajFTPDownload(unittest.TestCase):
     ftpd = FTPDownload('ftp', 'speedtest.tele2.net', '/')
     (file_list, dir_list) = ftpd.list()
     ftpd.match([r'^1.*KB\.zip$'], file_list, dir_list)
-    try:
-        ftpd.download(self.utils.data_dir)
-    except Exception:
-        self.assertTrue(1==1)
-    else:
-        self.assertTrue(1==0)
+    ftpd.download(self.utils.data_dir)
     ftpd.close()
-    # self.assertTrue(len(ftpd.files_to_download) == 2)
+    self.assertTrue(len(ftpd.files_to_download) == 2)
 
   def test_download_skip_uncompress_checks(self):
     os.environ['UNCOMPRESS_SKIP_CHECK'] = "1"


### PR DESCRIPTION
The test in `TestBiomajFTPDownload.test_download` fails if no exception is raised when calling `ftpd.download` which doesn't seem correct (this was introduced in 83697701c5024d6bc1a228e62140fe8369c809cb but doesn't seem related).

This PR simplify the test (which passes most of the time).