### PR TITLE
Correctly handle direct protocols

### DIFF
--- a/biomaj_download/downloadservice.py
+++ b/biomaj_download/downloadservice.py
@@ -29,9 +29,10 @@ app_log = logging.getLogger('werkzeug')
 app_log.setLevel(logging.ERROR)
 
 # Classify protocols from downmessage.proto
-ALL_PROTOCOLS = [key for key, item in downmessage_pb2.DownloadFile.Protocol.items()]
+# Note: those lists are based on the protocol numbers, not the protocol names
+ALL_PROTOCOLS = [item for key, item in downmessage_pb2.DownloadFile.Protocol.items()]
 DIRECT_PROTOCOLS = [
-    key for key, item in downmessage_pb2.DownloadFile.Protocol.items()
+    item for key, item in downmessage_pb2.DownloadFile.Protocol.items()
     if key.startswith("DIRECT")
 ]
 


### PR DESCRIPTION
This PR solves a bug triggered by unit tests in biomaj (see genouest/biomaj#113): files to download for direct protocols are not set correctly.

This is because we don't detect correctly direct protocols which is ultimately because `ALL_PROTOCOLS` and `DIRECT_PROTOCOLS` must contain their numbers not their names.