### PR TITLE
Don't change name after download.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.28 [unreleased]:
+  #16 Don't change name after download in DirectHTTPDownloader
 3.0.27:
   Fix previous release broken with a bug in direct protocols
 3.0.26:

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -170,7 +170,6 @@ class DirectHttpDownload(DirectFTPDownload):
             curl.close()
             fp.close()
             self.logger.debug('downloaded!')
-            rfile['name'] = self.save_as
             self.set_permissions(file_path, rfile)
         return self.files_to_download
 


### PR DESCRIPTION
`DirectHTTPDownload` changes the `name` property of the downloaded file to `save_as`. genouest/biomaj#115 make this useless so this PR changes that.