### PR TITLE
Add a protocol option to set CURLOPT_FTP_FILEMETHOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,42 @@ If you cloned the repository and installed it via python setup.py install, just 
 Web processes should be behind a proxy/load balancer, API base url /api/download
 
 Prometheus endpoint metrics are exposed via /metrics on web server
+
+# Protocol options
+
+Since version 3.0.26, you can use the `set_options` method to pass a dictionary of protocol-specific options.
+The following list shows some options and their effect (the option to set is the key and the parameter is the associated value):
+
+  * **skip_check_uncompress**:
+    * parameter: bool.
+    * downloader(s): all.
+    * effect: If true, don't test the archives after download. Default: false (i.e. test the archives).
+  * **ssl_verifyhost**:
+    * parameter: bool.
+    * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
+    * effect: If false, don't check that the name of the remote server is the same than in the SSL certificate. Default: true (i.e. check host name).
+    * note: It's generally a bad idea to disable this verification. However some servers are badly configured. See [here](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html) for the corresponding cURL option.
+  * **ssl_verifypeer**:
+    * parameter: bool.
+    * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
+    * effect: If false, don't check the authenticity of the peer's certificate.  Default: true (i.e. check authenticity).
+    * note: It's generally a bad idea to disable this verification. However some servers are badly configured. See [here](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html) for the corresponding cURL option.
+  * **ssl_server_cert**:
+    * parameter: filename of the certificate.
+    * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
+    * effect: Pass a file holding one or more certificates to verify the peer with. Default: use OS certificate.
+    * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html) for the corresponding cURL option.
+  * **tcp_keepalive**
+    * parameter: int.
+    * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
+    * effect: Sets the interval, in seconds, that the operating system will wait between sending keepalive probes. Default: cURL default (60s at the time of this writing).
+    * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_TCP_KEEPINTVL.html) for the corresponding cURL option.
+  * **ftp_method**
+    * parameter: one of `default`, `multicwd`, `nocwd`, `singlecwd` (case insensitive).
+    * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
+    * effect: Sets the method to use to reach a file on a FTP(S) server (`nocwd` and `singlecwd` are usually faster but not always supported). Default: `default` (which is `multicwd` at the time of this writing)
+    * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html) for the corresponding cURL option.
+
+Those options can be set in bank properties.
+See file `global.properties.example` in [biomaj module](https://github.com/genouest/biomaj).
+

--- a/README.md
+++ b/README.md
@@ -67,31 +67,37 @@ The following list shows some options and their effect (the option to set is the
   * **skip_check_uncompress**:
     * parameter: bool.
     * downloader(s): all.
-    * effect: If true, don't test the archives after download. Default: false (i.e. test the archives).
+    * effect: If true, don't test the archives after download.
+    * default: false (i.e. test the archives).
   * **ssl_verifyhost**:
     * parameter: bool.
     * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
-    * effect: If false, don't check that the name of the remote server is the same than in the SSL certificate. Default: true (i.e. check host name).
+    * effect: If false, don't check that the name of the remote server is the same than in the SSL certificate.
+    * default: true (i.e. check host name).
     * note: It's generally a bad idea to disable this verification. However some servers are badly configured. See [here](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html) for the corresponding cURL option.
   * **ssl_verifypeer**:
     * parameter: bool.
     * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
-    * effect: If false, don't check the authenticity of the peer's certificate.  Default: true (i.e. check authenticity).
+    * effect: If false, don't check the authenticity of the peer's certificate.
+    * default: true (i.e. check authenticity).
     * note: It's generally a bad idea to disable this verification. However some servers are badly configured. See [here](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html) for the corresponding cURL option.
   * **ssl_server_cert**:
     * parameter: filename of the certificate.
     * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
-    * effect: Pass a file holding one or more certificates to verify the peer with. Default: use OS certificate.
+    * effect: Pass a file holding one or more certificates to verify the peer with.
+    * default: use OS certificates.
     * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html) for the corresponding cURL option.
-  * **tcp_keepalive**
+  * **tcp_keepalive**:
     * parameter: int.
     * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
-    * effect: Sets the interval, in seconds, that the operating system will wait between sending keepalive probes. Default: cURL default (60s at the time of this writing).
+    * effect: Sets the interval, in seconds, that the operating system will wait between sending keepalive probes.
+    * default: cURL default (60s at the time of this writing).
     * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_TCP_KEEPINTVL.html) for the corresponding cURL option.
-  * **ftp_method**
+  * **ftp_method**:
     * parameter: one of `default`, `multicwd`, `nocwd`, `singlecwd` (case insensitive).
     * downloader(s): `CurlDownloader`, `DirectFTPDownload`, `DirectHTTPDownload`.
-    * effect: Sets the method to use to reach a file on a FTP(S) server (`nocwd` and `singlecwd` are usually faster but not always supported). Default: `default` (which is `multicwd` at the time of this writing)
+    * effect: Sets the method to use to reach a file on a FTP(S) server (`nocwd` and `singlecwd` are usually faster but not always supported).
+    * default: `default` (which is `multicwd` at the time of this writing)
     * note: See [here](https://curl.haxx.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html) for the corresponding cURL option.
 
 Those options can be set in bank properties.

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -639,6 +639,20 @@ class TestBiomajFTPDownload(unittest.TestCase):
       ftpd.close()
       self.assertTrue(len(ftpd.files_to_download) == 1)
 
+  def test_download_ftp_method(self):
+      """
+      Test setting ftp_method (it probably doesn't change anything here but we
+      test that there is no obvious mistake in the code).
+      """
+      ftpd = CurlDownload("ftp", "test.rebex.net", "/")
+      ftpd.set_options(dict(ftp_method="nocwd"))
+      ftpd.set_credentials("demo:password")
+      (file_list, dir_list) = ftpd.list()
+      ftpd.match(["^readme.txt$"], file_list, dir_list)
+      ftpd.download(self.utils.data_dir)
+      ftpd.close()
+      self.assertTrue(len(ftpd.files_to_download) == 1)
+
 
 @attr('ftps')
 @attr('network')


### PR DESCRIPTION
This PR allows to pass an option to `CurlDownloader` to set [CURLOPT_FTP_FILEMETHOD](https://curl.haxx.se/libcurl/c/CURLOPT_FTP_FILEMETHOD.html). Some values (`nocwd` and `singlecwd`) allow to significantly speed up the download but are not always supported. Both are supported on NCBI's ftp server for instance.

The values to use are the ones valid for [the corresponding CLI option (--ftp-method)](https://curl.haxx.se/docs/manpage.html#--ftp-method) plus `default`.

AFAIU we don't need to modify other packages to support that in banks.