### PR TITLE
Rename protocol options to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Web processes should be behind a proxy/load balancer, API base url /api/download
 
 Prometheus endpoint metrics are exposed via /metrics on web server
 
-# Protocol options
+# Download options
 
-Since version 3.0.26, you can use the `set_options` method to pass a dictionary of protocol-specific options.
+Since version 3.0.26, you can use the `set_options` method to pass a dictionary of downloader-specific options.
 The following list shows some options and their effect (the option to set is the key and the parameter is the associated value):
 
   * **skip_check_uncompress**:
@@ -102,4 +102,3 @@ The following list shows some options and their effect (the option to set is the
 
 Those options can be set in bank properties.
 See file `global.properties.example` in [biomaj module](https://github.com/genouest/biomaj).
-

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -263,20 +263,20 @@ class CurlDownload(DownloadInterface):
         super(CurlDownload, self).set_server(server)
         self.url = self.curl_protocol + '://' + self.server
 
-    def set_options(self, protocol_options):
-        super(CurlDownload, self).set_options(protocol_options)
-        if "ssl_verifyhost" in protocol_options:
-            self.ssl_verifyhost = Utils.to_bool(protocol_options["ssl_verifyhost"])
-        if "ssl_verifypeer" in protocol_options:
-            self.ssl_verifypeer = Utils.to_bool(protocol_options["ssl_verifypeer"])
-        if "ssl_server_cert" in protocol_options:
-            self.ssl_server_cert = protocol_options["ssl_server_cert"]
-        if "tcp_keepalive" in protocol_options:
-            self.tcp_keepalive = Utils.to_int(protocol_options["tcp_keepalive"])
-        if "ftp_method" in protocol_options:
+    def set_options(self, options):
+        super(CurlDownload, self).set_options(options)
+        if "ssl_verifyhost" in options:
+            self.ssl_verifyhost = Utils.to_bool(options["ssl_verifyhost"])
+        if "ssl_verifypeer" in options:
+            self.ssl_verifypeer = Utils.to_bool(options["ssl_verifypeer"])
+        if "ssl_server_cert" in options:
+            self.ssl_server_cert = options["ssl_server_cert"]
+        if "tcp_keepalive" in options:
+            self.tcp_keepalive = Utils.to_int(options["tcp_keepalive"])
+        if "ftp_method" in options:
             # raw_val is a string which contains the name of the option as in the CLI.
             # We always convert raw_val to a valid integer
-            raw_val = protocol_options["ftp_method"].lower()
+            raw_val = options["ftp_method"].lower()
             if raw_val not in self.VALID_FTP_FILEMETHOD:
                 raise ValueError("Invalid value for ftp_method")
             self.ftp_method = self.VALID_FTP_FILEMETHOD[raw_val]

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -68,7 +68,7 @@ class DownloadInterface(object):
         self.server = None
         self.offline_dir = None
         # Options
-        self.protocol_options = {}
+        self.options = {}  # This field is used to forge the download message
         self.skip_check_uncompress = False
 
     #
@@ -128,16 +128,16 @@ class DownloadInterface(object):
         '''
         self.credentials = userpwd
 
-    def set_options(self, protocol_options):
+    def set_options(self, options):
         """
-        Set protocol specific options.
+        Set download options.
 
-        Subclasses that override this method must call the
-        parent implementation.
+        Subclasses that override this method must call this implementation.
         """
-        self.protocol_options = protocol_options
-        if "skip_check_uncompress" in protocol_options:
-            self.skip_check_uncompress = Utils.to_bool(protocol_options["skip_check_uncompress"])
+        # Copy the option dict
+        self.options = options
+        if "skip_check_uncompress" in options:
+            self.skip_check_uncompress = Utils.to_bool(options["skip_check_uncompress"])
 
     #
     # File operations (match, list, download) and associated hook methods

--- a/biomaj_download/downloadservice.py
+++ b/biomaj_download/downloadservice.py
@@ -130,7 +130,7 @@ class DownloadService(object):
                     credentials=None, http_parse=None, http_method=None, param=None,
                     proxy=None, proxy_auth='',
                     save_as=None, timeout_download=None, offline_dir=None,
-                    protocol_options={}):
+                    options={}):
         protocol = downmessage_pb2.DownloadFile.Protocol.Value(protocol_name.upper())
         downloader = None
         if protocol in [0, 1]:  # FTP, SFTP
@@ -190,9 +190,9 @@ class DownloadService(object):
         # Set the name of the BioMAJ protocol to which we respond.
         downloader.set_protocol(protocol_name)
 
-        if protocol_options is not None:
-            self.logger.debug("Received protocol options: " + str(protocol_options))
-            downloader.set_options(protocol_options)
+        if options is not None:
+            self.logger.debug("Received options: " + str(options))
+            downloader.set_options(options)
 
         downloader.logger = self.logger
         downloader.set_files_to_download(remote_files)
@@ -243,7 +243,7 @@ class DownloadService(object):
                                 save_as=biomaj_file_info.remote_file.save_as,
                                 timeout_download=biomaj_file_info.timeout_download,
                                 offline_dir=biomaj_file_info.local_dir,
-                                protocol_options=biomaj_file_info.protocol_options
+                                options=biomaj_file_info.options
                                 )
 
     def clean(self, biomaj_file_info=None):

--- a/biomaj_download/message/downmessage.proto
+++ b/biomaj_download/message/downmessage.proto
@@ -122,7 +122,7 @@ message DownloadFile {
     optional Proxy proxy = 6;
 
     optional HTTP_METHOD http_method = 8 [ default = GET];
-    
-    map<string, string> protocol_options = 9;
+
+    map<string, string> options = 9;
 
 }

--- a/biomaj_download/message/downmessage_pb2.py
+++ b/biomaj_download/message/downmessage_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='biomaj.download',
   syntax='proto2',
   serialized_options=None,
-  serialized_pb=_b('\n\x11\x64ownmessage.proto\x12\x0f\x62iomaj.download\"\x9d\x02\n\x04\x46ile\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\x0c\n\x04root\x18\x02 \x01(\t\x12\x0f\n\x07save_as\x18\x03 \x01(\t\x12\x0b\n\x03url\x18\x04 \x01(\t\x12\x30\n\x08metadata\x18\x05 \x01(\x0b\x32\x1e.biomaj.download.File.MetaData\x1a\xa8\x01\n\x08MetaData\x12\x13\n\x0bpermissions\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x0c\n\x04size\x18\x03 \x01(\x03\x12\x0c\n\x04hash\x18\x04 \x01(\t\x12\x0c\n\x04year\x18\x05 \x01(\x05\x12\r\n\x05month\x18\x06 \x01(\x05\x12\x0b\n\x03\x64\x61y\x18\x07 \x01(\x05\x12\x0e\n\x06\x66ormat\x18\x08 \x01(\t\x12\x0b\n\x03md5\x18\t \x01(\t\x12\x15\n\rdownload_time\x18\n \x01(\x03\"0\n\x08\x46ileList\x12$\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x15.biomaj.download.File\"\xaa\x02\n\tOperation\x12\x32\n\x04type\x18\x01 \x02(\x0e\x32$.biomaj.download.Operation.OPERATION\x12/\n\x08\x64ownload\x18\x02 \x01(\x0b\x32\x1d.biomaj.download.DownloadFile\x12)\n\x07process\x18\x03 \x01(\x0b\x32\x18.biomaj.download.Process\x12/\n\x05trace\x18\x04 \x01(\x0b\x32 .biomaj.download.Operation.Trace\x1a*\n\x05Trace\x12\x10\n\x08trace_id\x18\x01 \x02(\t\x12\x0f\n\x07span_id\x18\x02 \x02(\t\"0\n\tOPERATION\x12\x08\n\x04LIST\x10\x00\x12\x0c\n\x08\x44OWNLOAD\x10\x01\x12\x0b\n\x07PROCESS\x10\x02\"\x17\n\x07Process\x12\x0c\n\x04\x65xec\x18\x01 \x02(\t\"\xad\x0b\n\x0c\x44ownloadFile\x12\x0c\n\x04\x62\x61nk\x18\x01 \x02(\t\x12\x0f\n\x07session\x18\x02 \x02(\t\x12\x11\n\tlocal_dir\x18\x03 \x02(\t\x12\x18\n\x10timeout_download\x18\x04 \x01(\x05\x12=\n\x0bremote_file\x18\x05 \x02(\x0b\x32(.biomaj.download.DownloadFile.RemoteFile\x12\x32\n\x05proxy\x18\x06 \x01(\x0b\x32#.biomaj.download.DownloadFile.Proxy\x12\x43\n\x0bhttp_method\x18\x08 \x01(\x0e\x32).biomaj.download.DownloadFile.HTTP_METHOD:\x03GET\x12L\n\x10protocol_options\x18\t \x03(\x0b\x32\x32.biomaj.download.DownloadFile.ProtocolOptionsEntry\x1a$\n\x05Param\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\r\n\x05value\x18\x02 \x02(\t\x1a\xcd\x03\n\tHttpParse\x12\x91\x01\n\x08\x64ir_line\x18\x01 \x02(\t:\x7f<img[\\s]+src=\"[\\S]+\"[\\s]+alt=\"\\[DIR\\]\"[\\s]*/?>[\\s]*<a[\\s]+href=\"([\\S]+)/\"[\\s]*>.*([\\d]{2}-[\\w\\d]{2,5}-[\\d]{4}\\s[\\d]{2}:[\\d]{2})\x12\xa5\x01\n\tfile_line\x18\x02 \x02(\t:\x91\x01<img[\\s]+src=\"[\\S]+\"[\\s]+alt=\"\\[[\\s]+\\]\"[\\s]*/?>[\\s]<a[\\s]+href=\"([\\S]+)\".*([\\d]{2}-[\\w\\d]{2,5}-[\\d]{4}\\s[\\d]{2}:[\\d]{2})[\\s]+([\\d\\.]+[MKG]{0,1})\x12\x13\n\x08\x64ir_name\x18\x03 \x02(\x05:\x01\x31\x12\x13\n\x08\x64ir_date\x18\x04 \x02(\x05:\x01\x32\x12\x14\n\tfile_name\x18\x05 \x02(\x05:\x01\x31\x12\x14\n\tfile_date\x18\x06 \x02(\x05:\x01\x32\x12\x18\n\x10\x66ile_date_format\x18\x07 \x01(\t\x12\x14\n\tfile_size\x18\x08 \x02(\x05:\x01\x33\x1a\xb8\x02\n\nRemoteFile\x12$\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x15.biomaj.download.File\x12\x38\n\x08protocol\x18\x02 \x02(\x0e\x32&.biomaj.download.DownloadFile.Protocol\x12\x0e\n\x06server\x18\x03 \x02(\t\x12\x12\n\nremote_dir\x18\x04 \x02(\t\x12\x0f\n\x07save_as\x18\x05 \x01(\t\x12\x32\n\x05param\x18\x06 \x03(\x0b\x32#.biomaj.download.DownloadFile.Param\x12;\n\nhttp_parse\x18\x07 \x01(\x0b\x32\'.biomaj.download.DownloadFile.HttpParse\x12\x13\n\x0b\x63redentials\x18\x08 \x01(\t\x12\x0f\n\x07matches\x18\t \x03(\t\x1a*\n\x05Proxy\x12\r\n\x05proxy\x18\x01 \x02(\t\x12\x12\n\nproxy_auth\x18\x02 \x01(\t\x1a\x36\n\x14ProtocolOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x93\x01\n\x08Protocol\x12\x07\n\x03\x46TP\x10\x00\x12\x08\n\x04\x46TPS\x10\x01\x12\x08\n\x04HTTP\x10\x02\x12\t\n\x05HTTPS\x10\x03\x12\r\n\tDIRECTFTP\x10\x04\x12\x0e\n\nDIRECTHTTP\x10\x05\x12\x0f\n\x0b\x44IRECTHTTPS\x10\x06\x12\t\n\x05LOCAL\x10\x07\x12\t\n\x05RSYNC\x10\x08\x12\t\n\x05IRODS\x10\t\x12\x0e\n\nDIRECTFTPS\x10\n\" \n\x0bHTTP_METHOD\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01')
+  serialized_pb=_b('\n\x11\x64ownmessage.proto\x12\x0f\x62iomaj.download\"\x9d\x02\n\x04\x46ile\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\x0c\n\x04root\x18\x02 \x01(\t\x12\x0f\n\x07save_as\x18\x03 \x01(\t\x12\x0b\n\x03url\x18\x04 \x01(\t\x12\x30\n\x08metadata\x18\x05 \x01(\x0b\x32\x1e.biomaj.download.File.MetaData\x1a\xa8\x01\n\x08MetaData\x12\x13\n\x0bpermissions\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x0c\n\x04size\x18\x03 \x01(\x03\x12\x0c\n\x04hash\x18\x04 \x01(\t\x12\x0c\n\x04year\x18\x05 \x01(\x05\x12\r\n\x05month\x18\x06 \x01(\x05\x12\x0b\n\x03\x64\x61y\x18\x07 \x01(\x05\x12\x0e\n\x06\x66ormat\x18\x08 \x01(\t\x12\x0b\n\x03md5\x18\t \x01(\t\x12\x15\n\rdownload_time\x18\n \x01(\x03\"0\n\x08\x46ileList\x12$\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x15.biomaj.download.File\"\xaa\x02\n\tOperation\x12\x32\n\x04type\x18\x01 \x02(\x0e\x32$.biomaj.download.Operation.OPERATION\x12/\n\x08\x64ownload\x18\x02 \x01(\x0b\x32\x1d.biomaj.download.DownloadFile\x12)\n\x07process\x18\x03 \x01(\x0b\x32\x18.biomaj.download.Process\x12/\n\x05trace\x18\x04 \x01(\x0b\x32 .biomaj.download.Operation.Trace\x1a*\n\x05Trace\x12\x10\n\x08trace_id\x18\x01 \x02(\t\x12\x0f\n\x07span_id\x18\x02 \x02(\t\"0\n\tOPERATION\x12\x08\n\x04LIST\x10\x00\x12\x0c\n\x08\x44OWNLOAD\x10\x01\x12\x0b\n\x07PROCESS\x10\x02\"\x17\n\x07Process\x12\x0c\n\x04\x65xec\x18\x01 \x02(\t\"\x94\x0b\n\x0c\x44ownloadFile\x12\x0c\n\x04\x62\x61nk\x18\x01 \x02(\t\x12\x0f\n\x07session\x18\x02 \x02(\t\x12\x11\n\tlocal_dir\x18\x03 \x02(\t\x12\x18\n\x10timeout_download\x18\x04 \x01(\x05\x12=\n\x0bremote_file\x18\x05 \x02(\x0b\x32(.biomaj.download.DownloadFile.RemoteFile\x12\x32\n\x05proxy\x18\x06 \x01(\x0b\x32#.biomaj.download.DownloadFile.Proxy\x12\x43\n\x0bhttp_method\x18\x08 \x01(\x0e\x32).biomaj.download.DownloadFile.HTTP_METHOD:\x03GET\x12;\n\x07options\x18\t \x03(\x0b\x32*.biomaj.download.DownloadFile.OptionsEntry\x1a$\n\x05Param\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\r\n\x05value\x18\x02 \x02(\t\x1a\xcd\x03\n\tHttpParse\x12\x91\x01\n\x08\x64ir_line\x18\x01 \x02(\t:\x7f<img[\\s]+src=\"[\\S]+\"[\\s]+alt=\"\\[DIR\\]\"[\\s]*/?>[\\s]*<a[\\s]+href=\"([\\S]+)/\"[\\s]*>.*([\\d]{2}-[\\w\\d]{2,5}-[\\d]{4}\\s[\\d]{2}:[\\d]{2})\x12\xa5\x01\n\tfile_line\x18\x02 \x02(\t:\x91\x01<img[\\s]+src=\"[\\S]+\"[\\s]+alt=\"\\[[\\s]+\\]\"[\\s]*/?>[\\s]<a[\\s]+href=\"([\\S]+)\".*([\\d]{2}-[\\w\\d]{2,5}-[\\d]{4}\\s[\\d]{2}:[\\d]{2})[\\s]+([\\d\\.]+[MKG]{0,1})\x12\x13\n\x08\x64ir_name\x18\x03 \x02(\x05:\x01\x31\x12\x13\n\x08\x64ir_date\x18\x04 \x02(\x05:\x01\x32\x12\x14\n\tfile_name\x18\x05 \x02(\x05:\x01\x31\x12\x14\n\tfile_date\x18\x06 \x02(\x05:\x01\x32\x12\x18\n\x10\x66ile_date_format\x18\x07 \x01(\t\x12\x14\n\tfile_size\x18\x08 \x02(\x05:\x01\x33\x1a\xb8\x02\n\nRemoteFile\x12$\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x15.biomaj.download.File\x12\x38\n\x08protocol\x18\x02 \x02(\x0e\x32&.biomaj.download.DownloadFile.Protocol\x12\x0e\n\x06server\x18\x03 \x02(\t\x12\x12\n\nremote_dir\x18\x04 \x02(\t\x12\x0f\n\x07save_as\x18\x05 \x01(\t\x12\x32\n\x05param\x18\x06 \x03(\x0b\x32#.biomaj.download.DownloadFile.Param\x12;\n\nhttp_parse\x18\x07 \x01(\x0b\x32\'.biomaj.download.DownloadFile.HttpParse\x12\x13\n\x0b\x63redentials\x18\x08 \x01(\t\x12\x0f\n\x07matches\x18\t \x03(\t\x1a*\n\x05Proxy\x12\r\n\x05proxy\x18\x01 \x02(\t\x12\x12\n\nproxy_auth\x18\x02 \x01(\t\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x93\x01\n\x08Protocol\x12\x07\n\x03\x46TP\x10\x00\x12\x08\n\x04\x46TPS\x10\x01\x12\x08\n\x04HTTP\x10\x02\x12\t\n\x05HTTPS\x10\x03\x12\r\n\tDIRECTFTP\x10\x04\x12\x0e\n\nDIRECTHTTP\x10\x05\x12\x0f\n\x0b\x44IRECTHTTPS\x10\x06\x12\t\n\x05LOCAL\x10\x07\x12\t\n\x05RSYNC\x10\x08\x12\t\n\x05IRODS\x10\t\x12\x0e\n\nDIRECTFTPS\x10\n\" \n\x0bHTTP_METHOD\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01')
 )
 
 
@@ -103,8 +103,8 @@ _DOWNLOADFILE_PROTOCOL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1975,
-  serialized_end=2122,
+  serialized_start=1950,
+  serialized_end=2097,
 )
 _sym_db.RegisterEnumDescriptor(_DOWNLOADFILE_PROTOCOL)
 
@@ -125,8 +125,8 @@ _DOWNLOADFILE_HTTP_METHOD = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2124,
-  serialized_end=2156,
+  serialized_start=2099,
+  serialized_end=2131,
 )
 _sym_db.RegisterEnumDescriptor(_DOWNLOADFILE_HTTP_METHOD)
 
@@ -468,8 +468,8 @@ _DOWNLOADFILE_PARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1057,
-  serialized_end=1093,
+  serialized_start=1040,
+  serialized_end=1076,
 )
 
 _DOWNLOADFILE_HTTPPARSE = _descriptor.Descriptor(
@@ -547,8 +547,8 @@ _DOWNLOADFILE_HTTPPARSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1096,
-  serialized_end=1557,
+  serialized_start=1079,
+  serialized_end=1540,
 )
 
 _DOWNLOADFILE_REMOTEFILE = _descriptor.Descriptor(
@@ -633,8 +633,8 @@ _DOWNLOADFILE_REMOTEFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1560,
-  serialized_end=1872,
+  serialized_start=1543,
+  serialized_end=1855,
 )
 
 _DOWNLOADFILE_PROXY = _descriptor.Descriptor(
@@ -670,26 +670,26 @@ _DOWNLOADFILE_PROXY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1874,
-  serialized_end=1916,
+  serialized_start=1857,
+  serialized_end=1899,
 )
 
-_DOWNLOADFILE_PROTOCOLOPTIONSENTRY = _descriptor.Descriptor(
-  name='ProtocolOptionsEntry',
-  full_name='biomaj.download.DownloadFile.ProtocolOptionsEntry',
+_DOWNLOADFILE_OPTIONSENTRY = _descriptor.Descriptor(
+  name='OptionsEntry',
+  full_name='biomaj.download.DownloadFile.OptionsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='biomaj.download.DownloadFile.ProtocolOptionsEntry.key', index=0,
+      name='key', full_name='biomaj.download.DownloadFile.OptionsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='biomaj.download.DownloadFile.ProtocolOptionsEntry.value', index=1,
+      name='value', full_name='biomaj.download.DownloadFile.OptionsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -707,8 +707,8 @@ _DOWNLOADFILE_PROTOCOLOPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1918,
-  serialized_end=1972,
+  serialized_start=1901,
+  serialized_end=1947,
 )
 
 _DOWNLOADFILE = _descriptor.Descriptor(
@@ -768,7 +768,7 @@ _DOWNLOADFILE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='protocol_options', full_name='biomaj.download.DownloadFile.protocol_options', index=7,
+      name='options', full_name='biomaj.download.DownloadFile.options', index=7,
       number=9, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -777,7 +777,7 @@ _DOWNLOADFILE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_DOWNLOADFILE_PARAM, _DOWNLOADFILE_HTTPPARSE, _DOWNLOADFILE_REMOTEFILE, _DOWNLOADFILE_PROXY, _DOWNLOADFILE_PROTOCOLOPTIONSENTRY, ],
+  nested_types=[_DOWNLOADFILE_PARAM, _DOWNLOADFILE_HTTPPARSE, _DOWNLOADFILE_REMOTEFILE, _DOWNLOADFILE_PROXY, _DOWNLOADFILE_OPTIONSENTRY, ],
   enum_types=[
     _DOWNLOADFILE_PROTOCOL,
     _DOWNLOADFILE_HTTP_METHOD,
@@ -789,7 +789,7 @@ _DOWNLOADFILE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=703,
-  serialized_end=2156,
+  serialized_end=2131,
 )
 
 _FILE_METADATA.containing_type = _FILE
@@ -809,11 +809,11 @@ _DOWNLOADFILE_REMOTEFILE.fields_by_name['param'].message_type = _DOWNLOADFILE_PA
 _DOWNLOADFILE_REMOTEFILE.fields_by_name['http_parse'].message_type = _DOWNLOADFILE_HTTPPARSE
 _DOWNLOADFILE_REMOTEFILE.containing_type = _DOWNLOADFILE
 _DOWNLOADFILE_PROXY.containing_type = _DOWNLOADFILE
-_DOWNLOADFILE_PROTOCOLOPTIONSENTRY.containing_type = _DOWNLOADFILE
+_DOWNLOADFILE_OPTIONSENTRY.containing_type = _DOWNLOADFILE
 _DOWNLOADFILE.fields_by_name['remote_file'].message_type = _DOWNLOADFILE_REMOTEFILE
 _DOWNLOADFILE.fields_by_name['proxy'].message_type = _DOWNLOADFILE_PROXY
 _DOWNLOADFILE.fields_by_name['http_method'].enum_type = _DOWNLOADFILE_HTTP_METHOD
-_DOWNLOADFILE.fields_by_name['protocol_options'].message_type = _DOWNLOADFILE_PROTOCOLOPTIONSENTRY
+_DOWNLOADFILE.fields_by_name['options'].message_type = _DOWNLOADFILE_OPTIONSENTRY
 _DOWNLOADFILE_PROTOCOL.containing_type = _DOWNLOADFILE
 _DOWNLOADFILE_HTTP_METHOD.containing_type = _DOWNLOADFILE
 DESCRIPTOR.message_types_by_name['File'] = _FILE
@@ -897,10 +897,10 @@ DownloadFile = _reflection.GeneratedProtocolMessageType('DownloadFile', (_messag
     ))
   ,
 
-  ProtocolOptionsEntry = _reflection.GeneratedProtocolMessageType('ProtocolOptionsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _DOWNLOADFILE_PROTOCOLOPTIONSENTRY,
+  OptionsEntry = _reflection.GeneratedProtocolMessageType('OptionsEntry', (_message.Message,), dict(
+    DESCRIPTOR = _DOWNLOADFILE_OPTIONSENTRY,
     __module__ = 'downmessage_pb2'
-    # @@protoc_insertion_point(class_scope:biomaj.download.DownloadFile.ProtocolOptionsEntry)
+    # @@protoc_insertion_point(class_scope:biomaj.download.DownloadFile.OptionsEntry)
     ))
   ,
   DESCRIPTOR = _DOWNLOADFILE,
@@ -912,8 +912,8 @@ _sym_db.RegisterMessage(DownloadFile.Param)
 _sym_db.RegisterMessage(DownloadFile.HttpParse)
 _sym_db.RegisterMessage(DownloadFile.RemoteFile)
 _sym_db.RegisterMessage(DownloadFile.Proxy)
-_sym_db.RegisterMessage(DownloadFile.ProtocolOptionsEntry)
+_sym_db.RegisterMessage(DownloadFile.OptionsEntry)
 
 
-_DOWNLOADFILE_PROTOCOLOPTIONSENTRY._options = None
+_DOWNLOADFILE_OPTIONSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -230,7 +230,7 @@ class TestBiomajLocalDownload(unittest.TestCase):
     except Exception:
       msg = "In %s: copy worked but hardlinks were not used." % self.id()
       logging.info(msg)
-      
+
 @attr('network')
 @attr('http')
 class TestBiomajHTTPDownload(unittest.TestCase):
@@ -365,7 +365,7 @@ class TestBiomajSFTPDownload(unittest.TestCase):
   """
 
   PROTOCOL = "ftps"
-  
+
   def setUp(self):
     self.utils = UtilsForTest()
 
@@ -420,7 +420,7 @@ class TestBiomajDirectFTPSDownload(unittest.TestCase):
   """
   Test DirectFTP downloader with FTPS.
   """
-  
+
   def setUp(self):
     self.utils = UtilsForTest()
 


### PR DESCRIPTION
This PR renames  the `protocol_options` mechanisms to `options` because it's more clear.

This includes:

- renaming the field `protocol_options` to `options` in the `Download` (protobuf) message: this doesn't affect message compatibility (because field names are not used, only their index) but slightly change the way to construct the message from pyhton
- renaming the `protocol_options` member to `options` in `DownloadInterface` and similarly renaming the `protocol_options` parameter in the `set_options` method to `options`

This slightly breaks the API.

A corresponding PR must be done in genouest/biomaj#118 to adapt the code (calls to `get_handler`, message construction, internal variables).

Unit tests pass. Integrations tests will be done in the corresponding PR in genouest/biomaj#118.