### PR TITLE
Add a configurable mechanism to retry download when it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Examples (inspired by Tenacity doc):
   * `"wait_none + wait_random(1,2)"` will wait between 1s and 2s (since `wait_none` doesn't wait).
   * `"stop_never | stop_after_attempt(5)"` will stop after 5 attempts (since `stop_never` never stops).
 
+Note that some protocols (e.g. FTP) classify errors as temporary or permanent (for example trying to download inexisting file).
+In our experience, so called permanent errors may well be temporary.
+Therefore downloaders always retry whatever the error.
+In some cases, this is a waste of time but generally this is worth it.
+
 # Download options
 
 Since version 3.0.26, you can use the `set_options` method to pass a dictionary of downloader-specific options.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A common problem when downloading a large number of files is the handling of tem
 Since version 3.1.2, `biomaj-download` uses the [Tenacity library](https://github.com/jd/tenacity) which is designed to handle this.
 
 This mechanism is configurable through 2 downloader-specific options (see below): **stop_condition** and **wait_condition**.
-When working on python code, you can pass instances of `stop_base` and `wait_base` respectively.
+When working on python code, you can pass instances of Tenacity's `stop_base` and `wait_base` respectively.
 This includes classes defined in Tenacity or your own derived classes.
 
 For bank configuration those options also parse strings read from the configuration file.
@@ -75,9 +75,9 @@ The rules are straightforward:
   * All concrete stop and wait classes defined in Tenacity (i.e. classes inheriting from `stop_base` and `wait_base` respectively) can be used
     by calling their constructor with the expected parameters.
     For example, the string `"stop_after_attempt(5)"` will create the desired object.
-    You can use classes that allow to combine other stop or wait conditions (namely `wait_combine`, `stop_all` and `stop_any`).
 	Note that stop and wait classes that need no argument must be used as constants (i.e. use `"stop_never"` and not `"stop_never()"`).
-	Currently, this is the case for `"stop_never"` and `"wait_none"`.
+	Currently, this is the case for `"stop_never"` (as in Tenacity) and `"wait_none"` (this slightly differs from Tenacity where it is `"wait_none()"`).
+  * You can use classes that allow to combine other stop or wait conditions (namely `wait_combine`, `stop_all` and `stop_any`).
   * Operator `+` can be used to add wait conditions (similar to `wait_combine`).
   * Operators `&` and `|` can be used to compose stop conditions (similar to `wait_all` and `wait_none` respectively).
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Examples (inspired by Tenacity doc):
   * `"stop_never | stop_after_attempt(5)"` will stop after 5 attempts (since `stop_never` never stops).
 
 Note that some protocols (e.g. FTP) classify errors as temporary or permanent (for example trying to download inexisting file).
-In our experience, so called permanent errors may well be temporary.
+More generally, we could distinguish permanent errors based on error codes, etc. and not retry in this case.
+However in our experience, so called permanent errors may well be temporary.
 Therefore downloaders always retry whatever the error.
 In some cases, this is a waste of time but generally this is worth it.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Prometheus endpoint metrics are exposed via /metrics on web server
 A common problem when downloading a large number of files is the handling of temporary failures (network issues, server too busy to answer, etc.).
 Since version 3.1.2, `biomaj-download` uses the [Tenacity library](https://github.com/jd/tenacity) which is designed to handle this.
 
-This mechanism is configurable through 2 downloader-specific options (see below): **stop_condition** and **wait_condition**.
+This mechanism is configurable through 2 downloader-specific options (see below): **stop_condition** and **wait_policy**.
 When working on python code, you can pass instances of Tenacity's `stop_base` and `wait_base` respectively.
 This includes classes defined in Tenacity or your own derived classes.
 
@@ -77,8 +77,8 @@ The rules are straightforward:
     For example, the string `"stop_after_attempt(5)"` will create the desired object.
 	Note that stop and wait classes that need no argument must be used as constants (i.e. use `"stop_never"` and not `"stop_never()"`).
 	Currently, this is the case for `"stop_never"` (as in Tenacity) and `"wait_none"` (this slightly differs from Tenacity where it is `"wait_none()"`).
-  * You can use classes that allow to combine other stop or wait conditions (namely `wait_combine`, `stop_all` and `stop_any`).
-  * Operator `+` can be used to add wait conditions (similar to `wait_combine`).
+  * You can use classes that allow to combine other stop conditions (namely `stop_all` and `stop_any`) or wait policies (namely `wait_combine`).
+  * Operator `+` can be used to add wait policies (similar to `wait_combine`).
   * Operators `&` and `|` can be used to compose stop conditions (similar to `wait_all` and `wait_none` respectively).
 
 However, in this case, you can't use your own conditions.
@@ -91,7 +91,7 @@ The complete list of stop conditions is:
 * `stop_all`
 * `stop_any`
 
-The complete list of wait conditions is:
+The complete list of wait policies is:
 
 * `wait_none`
 * `wait_fixed`
@@ -127,7 +127,7 @@ The following list shows some options and their effect (the option to set is the
     * downloader(s): all (except LocalDownloader).
     * effect: sets the condition on which we should stop retrying to download a file.
     * default: .
-  * **wait_condition**:
+  * **wait_policy**:
     * parameter: an instance of Tenacity `wait_base` or a string (see above).
     * downloader(s): all (except LocalDownloader).
     * effect: sets the wait policy between download trials.

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import re
 from datetime import datetime
 import hashlib
@@ -301,7 +300,7 @@ class CurlDownload(DownloadInterface):
         error = True
         # Forge URL of remote file
         file_url = self._file_url(rfile)
-        
+
         self._basic_curl_configuration()
 
         try:
@@ -337,16 +336,11 @@ class CurlDownload(DownloadInterface):
         # Close file
         fp.close()
 
-        # Check that the archive is correct
-        if not error and not self.skip_check_uncompress:
-            archive_status = Utils.archive_check(file_path)
-            if not archive_status:
-                self.logger.error('Archive is invalid or corrupted, deleting file and retrying download')
-                error = True
-                if os.path.exists(file_path):
-                    os.remove(file_path)
+        if error:
+            return error
 
-        return error
+        # Our part is done so call parent _download
+        return super(CurlDownload, self)._download(file_path, rfile)
 
     def list(self, directory=''):
         '''

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -299,57 +299,52 @@ class CurlDownload(DownloadInterface):
         This method is designed to work for FTP(S), HTTP(S) and SFTP.
         """
         error = True
-        nbtry = 1
         # Forge URL of remote file
         file_url = self._file_url(rfile)
-        while(error is True and nbtry < 3):
+        
+        self._basic_curl_configuration()
 
-            self._basic_curl_configuration()
+        try:
+            self.crl.setopt(pycurl.URL, file_url)
+        except Exception:
+            self.crl.setopt(pycurl.URL, file_url.encode('ascii', 'ignore'))
 
-            try:
-                self.crl.setopt(pycurl.URL, file_url)
-            except Exception:
-                self.crl.setopt(pycurl.URL, file_url.encode('ascii', 'ignore'))
+        # Create file and assign it to the pycurl object
+        fp = open(file_path, "wb")
+        self.crl.setopt(pycurl.WRITEFUNCTION, fp.write)
 
-            # Create file and assign it to the pycurl object
-            fp = open(file_path, "wb")
-            self.crl.setopt(pycurl.WRITEFUNCTION, fp.write)
+        # This is specific to HTTP
+        if self.method == 'POST':
+            # Form data must be provided already urlencoded.
+            postfields = urlencode(self.param)
+            # Sets request method to POST,
+            # Content-Type header to application/x-www-form-urlencoded
+            # and data to send in request body.
+            self.crl.setopt(pycurl.POSTFIELDS, postfields)
 
-            # This is specific to HTTP
-            if self.method == 'POST':
-                # Form data must be provided already urlencoded.
-                postfields = urlencode(self.param)
-                # Sets request method to POST,
-                # Content-Type header to application/x-www-form-urlencoded
-                # and data to send in request body.
-                self.crl.setopt(pycurl.POSTFIELDS, postfields)
+        # Try download
+        try:
+            self.crl.perform()
+            errcode = self.crl.getinfo(pycurl.RESPONSE_CODE)
+            if int(errcode) != self.ERRCODE_OK:
+                error = True
+                self.logger.error('Error while downloading ' + file_url + ' - ' + str(errcode))
+            else:
+                error = False
+        except Exception as e:
+            self.logger.error('Could not get errcode:' + str(e))
 
-            # Try download
-            try:
-                self.crl.perform()
-                errcode = self.crl.getinfo(pycurl.RESPONSE_CODE)
-                if int(errcode) != self.ERRCODE_OK:
-                    error = True
-                    self.logger.error('Error while downloading ' + file_url + ' - ' + str(errcode))
-                else:
-                    error = False
-            except Exception as e:
-                self.logger.error('Could not get errcode:' + str(e))
+        # Close file
+        fp.close()
 
-            # Close file
-            fp.close()
-
-            # Check that the archive is correct
-            if not error and not self.skip_check_uncompress:
-                archive_status = Utils.archive_check(file_path)
-                if not archive_status:
-                    self.logger.error('Archive is invalid or corrupted, deleting file and retrying download')
-                    error = True
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-
-            # Increment retry counter
-            nbtry += 1
+        # Check that the archive is correct
+        if not error and not self.skip_check_uncompress:
+            archive_status = Utils.archive_check(file_path)
+            if not archive_status:
+                self.logger.error('Archive is invalid or corrupted, deleting file and retrying download')
+                error = True
+                if os.path.exists(file_path):
+                    os.remove(file_path)
 
         return error
 

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -52,11 +52,24 @@ class DownloadInterface(object):
     #
     # Constants to parse retryer
     #
+    # Note that due to the current implementation of operators, tenacity allows
+    # nonsensical operations. For example the following snippets are valid:
+    # stop_after_attempt(1, 2) + 4
+    # stop_after_attempt(1, 2) + stop_none.
+    # Of course, trying to use those wait conditions will raise cryptic errors.
+    # The situation is similar for stop conditions.
+    # For parsing, this is particularly confusing if we consider stop_none as a
+    # function since then both "stop_none" and "stop_none()" are parsed
+    # and evaluated correctly but the later raises error. Considering it has a
+    # a name is slightly more clear (since then we must write "stop_none" but
+    # the code use the object which makes sense).
+    # See https://github.com/jd/tenacity/issues/211.
 
     # Functions available when parsing stop condition: those are constructors
     # of stop conditions classes (then using them will create objects). Note
     # that there is an exception for stop_never.
     ALL_STOP_CONDITIONS = {
+        #"stop_never": tenacity.stop._stop_never,  # In case, we want to use it like a function (see above)
         "stop_when_event_set": tenacity.stop_when_event_set,
         "stop_after_attempt": tenacity.stop_after_attempt,
         "stop_after_delay": tenacity.stop_after_delay,
@@ -81,6 +94,7 @@ class DownloadInterface(object):
     # of wait conditions classes (then using them will create objects). Note
     # that there is an exception for wait_none.
     ALL_WAIT_CONDITIONS = {
+        # "wait_none": tenacity.wait_none,  # In case, we want to use it like a function (see above)
         "wait_fixed": tenacity.wait_fixed,
         "wait_random": tenacity.wait_random,
         "wait_incrementing": tenacity.wait_incrementing,

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -4,6 +4,8 @@ import datetime
 import time
 import re
 
+import six
+
 import tenacity
 from simpleeval import simple_eval, ast
 
@@ -484,28 +486,41 @@ class DownloadInterface(object):
         Add a retryer to retry the current download if it fails.
         """
         # Try to construct stop condition
-        if not isinstance(stop_condition, tenacity.stop.stop_base):
+        if isinstance(stop_condition, tenacity.stop.stop_base):
+            # Use the value directly
+            stop_cond = stop_condition
+        elif isinstance(stop_condition, six.string_types):
+            # Try to parse the string
             try:
-                # Eval the string
                 stop_cond = simple_eval(stop_condition,
                                         functions=self.ALL_STOP_CONDITIONS,
                                         operators=self.ALL_STOP_OPERATORS,
                                         names=self.ALL_STOP_NAMES)
+                # Check that it is an instance of stop_base
+                if not isinstance(stop_cond, tenacity.stop.stop_base):
+                    raise ValueError(stop_condition + " doesn't yield a stop condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)
         else:
-            stop_cond = stop_condition
+            raise TypeError("Expected tenacity.stop.stop_base or string, got %s" % type(stop_condition))
         # Try to construct wait condition
-        if not isinstance(wait_condition, tenacity.wait.wait_base):
+        if isinstance(wait_condition, tenacity.wait.wait_base):
+            # Use the value directly
+            wait_cond = wait_condition
+        elif  isinstance(wait_condition, six.string_types):
+            # Try to parse the string
             try:
                 wait_cond = simple_eval(wait_condition,
                                         functions=self.ALL_WAIT_CONDITIONS,
                                         operators=self.ALL_WAIT_OPERATORS,
                                         names=self.ALL_WAIT_NAMES)
+                # Check that it is an instance of wait_base
+                if not isinstance(wait_cond, tenacity.wait.wait_base):
+                    raise ValueError(wait_condition + " doesn't yield a wait condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)
         else:
-            wait_cond = wait_condition
+            raise TypeError("Expected tenacity.stop.wait_base or string, got %s" % type(wait_condition))
 
         self.retryer = tenacity.Retrying(
             stop=stop_cond,

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -258,6 +258,11 @@ class DownloadInterface(object):
                 # Check that it is an instance of stop_base
                 if not isinstance(stop_cond, tenacity.stop.stop_base):
                     raise ValueError(stop_condition + " doesn't yield a stop condition")
+                # Test that this is a correct stop condition by calling it
+                try:
+                    stop_cond(tenacity.compat.make_retry_state(0, 0))
+                except:
+                    raise ValueError(stop_condition + " doesn't yield a stop condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)
         else:
@@ -276,6 +281,11 @@ class DownloadInterface(object):
                 # Check that it is an instance of wait_base
                 if not isinstance(wait_cond, tenacity.wait.wait_base):
                     raise ValueError(wait_condition + " doesn't yield a wait condition")
+                # Test that this is a correct wait condition by calling it
+                try:
+                    wait_cond(tenacity.compat.make_retry_state(0, 0))
+                except:
+                    raise ValueError(wait_condition + " doesn't yield a stop condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)
         else:

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -240,6 +240,55 @@ class DownloadInterface(object):
             wait_condition = options.get("wait_condition", BiomajConfig.DEFAULTS["wait_condition"])
             self._set_retryer(stop_condition, wait_condition)
 
+    def _set_retryer(self, stop_condition, wait_condition):
+        """
+        Add a retryer to retry the current download if it fails.
+        """
+        # Try to construct stop condition
+        if isinstance(stop_condition, tenacity.stop.stop_base):
+            # Use the value directly
+            stop_cond = stop_condition
+        elif isinstance(stop_condition, six.string_types):
+            # Try to parse the string
+            try:
+                stop_cond = simple_eval(stop_condition,
+                                        functions=self.ALL_STOP_CONDITIONS,
+                                        operators=self.ALL_STOP_OPERATORS,
+                                        names=self.ALL_STOP_NAMES)
+                # Check that it is an instance of stop_base
+                if not isinstance(stop_cond, tenacity.stop.stop_base):
+                    raise ValueError(stop_condition + " doesn't yield a stop condition")
+            except Exception as e:
+                raise ValueError("Error while parsing stop condition: %s" % e)
+        else:
+            raise TypeError("Expected tenacity.stop.stop_base or string, got %s" % type(stop_condition))
+        # Try to construct wait condition
+        if isinstance(wait_condition, tenacity.wait.wait_base):
+            # Use the value directly
+            wait_cond = wait_condition
+        elif  isinstance(wait_condition, six.string_types):
+            # Try to parse the string
+            try:
+                wait_cond = simple_eval(wait_condition,
+                                        functions=self.ALL_WAIT_CONDITIONS,
+                                        operators=self.ALL_WAIT_OPERATORS,
+                                        names=self.ALL_WAIT_NAMES)
+                # Check that it is an instance of wait_base
+                if not isinstance(wait_cond, tenacity.wait.wait_base):
+                    raise ValueError(wait_condition + " doesn't yield a wait condition")
+            except Exception as e:
+                raise ValueError("Error while parsing stop condition: %s" % e)
+        else:
+            raise TypeError("Expected tenacity.stop.wait_base or string, got %s" % type(wait_condition))
+
+        self.retryer = tenacity.Retrying(
+            stop=stop_cond,
+            wait=wait_cond,
+            retry_error_callback=self.return_last_value,
+            retry=tenacity.retry_if_result(self.is_true),
+            reraise=True
+        )
+
     #
     # File operations (match, list, download) and associated hook methods
     #
@@ -502,55 +551,6 @@ class DownloadInterface(object):
         Change directory
         '''
         pass
-
-    def _set_retryer(self, stop_condition, wait_condition):
-        """
-        Add a retryer to retry the current download if it fails.
-        """
-        # Try to construct stop condition
-        if isinstance(stop_condition, tenacity.stop.stop_base):
-            # Use the value directly
-            stop_cond = stop_condition
-        elif isinstance(stop_condition, six.string_types):
-            # Try to parse the string
-            try:
-                stop_cond = simple_eval(stop_condition,
-                                        functions=self.ALL_STOP_CONDITIONS,
-                                        operators=self.ALL_STOP_OPERATORS,
-                                        names=self.ALL_STOP_NAMES)
-                # Check that it is an instance of stop_base
-                if not isinstance(stop_cond, tenacity.stop.stop_base):
-                    raise ValueError(stop_condition + " doesn't yield a stop condition")
-            except Exception as e:
-                raise ValueError("Error while parsing stop condition: %s" % e)
-        else:
-            raise TypeError("Expected tenacity.stop.stop_base or string, got %s" % type(stop_condition))
-        # Try to construct wait condition
-        if isinstance(wait_condition, tenacity.wait.wait_base):
-            # Use the value directly
-            wait_cond = wait_condition
-        elif  isinstance(wait_condition, six.string_types):
-            # Try to parse the string
-            try:
-                wait_cond = simple_eval(wait_condition,
-                                        functions=self.ALL_WAIT_CONDITIONS,
-                                        operators=self.ALL_WAIT_OPERATORS,
-                                        names=self.ALL_WAIT_NAMES)
-                # Check that it is an instance of wait_base
-                if not isinstance(wait_cond, tenacity.wait.wait_base):
-                    raise ValueError(wait_condition + " doesn't yield a wait condition")
-            except Exception as e:
-                raise ValueError("Error while parsing stop condition: %s" % e)
-        else:
-            raise TypeError("Expected tenacity.stop.wait_base or string, got %s" % type(wait_condition))
-
-        self.retryer = tenacity.Retrying(
-            stop=stop_cond,
-            wait=wait_cond,
-            retry_error_callback=self.return_last_value,
-            retry=tenacity.retry_if_result(self.is_true),
-            reraise=True
-        )
 
     def close(self):
         '''

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -3,6 +3,7 @@ import logging
 import datetime
 import time
 import re
+import copy
 
 import six
 
@@ -263,9 +264,12 @@ class DownloadInterface(object):
                 # Check that it is an instance of stop_base
                 if not isinstance(stop_cond, tenacity.stop.stop_base):
                     raise ValueError(stop_condition + " doesn't yield a stop condition")
-                # Test that this is a correct stop condition by calling it
+                # Test that this is a correct stop condition by calling it.
+                # We use a deepcopy to be sure to not alter the object (even
+                # if it seems that calling a wait condition doesn't modify it).
                 try:
-                    stop_cond(tenacity.compat.make_retry_state(0, 0))
+                    s = copy.deepcopy(stop_cond)
+                    s(tenacity.compat.make_retry_state(0, 0))
                 except Exception:
                     raise ValueError(stop_condition + " doesn't yield a stop condition")
             except Exception as e:
@@ -286,9 +290,12 @@ class DownloadInterface(object):
                 # Check that it is an instance of wait_base
                 if not isinstance(wait_cond, tenacity.wait.wait_base):
                     raise ValueError(wait_condition + " doesn't yield a wait condition")
-                # Test that this is a correct wait condition by calling it
+                # Test that this is a correct wait condition by calling it.
+                # We use a deepcopy to be sure to not alter the object (even
+                # if it seems that calling a stop condition doesn't modify it).
                 try:
-                    wait_cond(tenacity.compat.make_retry_state(0, 0))
+                    w = copy.deepcopy(wait_cond)
+                    w(tenacity.compat.make_retry_state(0, 0))
                 except Exception:
                     raise ValueError(wait_condition + " doesn't yield a stop condition")
             except Exception as e:

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -266,7 +266,7 @@ class DownloadInterface(object):
         if isinstance(wait_condition, tenacity.wait.wait_base):
             # Use the value directly
             wait_cond = wait_condition
-        elif  isinstance(wait_condition, six.string_types):
+        elif isinstance(wait_condition, six.string_types):
             # Try to parse the string
             try:
                 wait_cond = simple_eval(wait_condition,

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -67,14 +67,14 @@ class DownloadInterface(object):
     # but the later raises error. Considering it has a name is slightly more
     # clear (since then we must write "stop_none" as we do when we use tenacity
     # directly). For consistency, we create a name for wait_none (as an
-     # instance of the class wait_none).
+    # instance of the class wait_none).
     #
 
     # Functions available when parsing stop condition: those are constructors
     # of stop conditions classes (then using them will create objects). Note
     # that there is an exception for stop_never.
     ALL_STOP_CONDITIONS = {
-        #"stop_never": tenacity.stop._stop_never,  # In case, we want to use it like a function (see above)
+        # "stop_never": tenacity.stop._stop_never,  # In case, we want to use it like a function (see above)
         "stop_when_event_set": tenacity.stop_when_event_set,
         "stop_after_attempt": tenacity.stop_after_attempt,
         "stop_after_delay": tenacity.stop_after_delay,
@@ -266,7 +266,7 @@ class DownloadInterface(object):
                 # Test that this is a correct stop condition by calling it
                 try:
                     stop_cond(tenacity.compat.make_retry_state(0, 0))
-                except:
+                except Exception:
                     raise ValueError(stop_condition + " doesn't yield a stop condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)
@@ -289,7 +289,7 @@ class DownloadInterface(object):
                 # Test that this is a correct wait condition by calling it
                 try:
                     wait_cond(tenacity.compat.make_retry_state(0, 0))
-                except:
+                except Exception:
                     raise ValueError(wait_condition + " doesn't yield a stop condition")
             except Exception as e:
                 raise ValueError("Error while parsing stop condition: %s" % e)

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -58,12 +58,17 @@ class DownloadInterface(object):
     # stop_after_attempt(1, 2) + stop_none.
     # Of course, trying to use those wait conditions will raise cryptic errors.
     # The situation is similar for stop conditions.
-    # For parsing, this is particularly confusing if we consider stop_none as a
-    # function since then both "stop_none" and "stop_none()" are parsed
-    # and evaluated correctly but the later raises error. Considering it has a
-    # a name is slightly more clear (since then we must write "stop_none" but
-    # the code use the object which makes sense).
     # See https://github.com/jd/tenacity/issues/211.
+    # To avoid such errors, we test the objects in _set_retryer.
+    #
+    # Another confusing issue is that stop_never is an object (instance of the
+    # class _stop_never). For parsing, if we consider stop_never as a
+    # function then both "stop_never" and "stop_never()" are parsed correctly
+    # but the later raises error. Considering it has a name is slightly more
+    # clear (since then we must write "stop_none" as we do when we use tenacity
+    # directly). For consistency, we create a name for wait_none (as an
+     # instance of the class wait_none).
+    #
 
     # Functions available when parsing stop condition: those are constructors
     # of stop conditions classes (then using them will create objects). Note

--- a/biomaj_download/download/protocolirods.py
+++ b/biomaj_download/download/protocolirods.py
@@ -59,7 +59,7 @@ class IRODSDownload(DownloadInterface):
         session.cleanup()
         return (rfiles, rdirs)
 
-    def _download(self, file_dir, rfile):
+    def _download(self, file_path, rfile):
         error = False
         self.logger.debug('IRODS:IRODS DOWNLOAD')
         session = iRODSSession(host=self.server, port=self.port,
@@ -73,12 +73,17 @@ class IRODSDownload(DownloadInterface):
                 file_to_get = rfile['root'] + "/" + rfile['name']
             # Write the file to download in the wanted file_dir with the
             # python-irods iget
-            obj = session.data_objects.get(file_to_get, file_dir)
+            obj = session.data_objects.get(file_to_get, file_path)
         except ExceptionIRODS as e:
             self.logger.error(self.__class__.__name__ + ":Download:Error:Can't get irods object " + str(obj))
             self.logger.error(self.__class__.__name__ + ":Download:Error:" + str(e))
         session.cleanup()
-        return(error)
+
+        if error:
+            return error
+
+        # Our part is done so call parent _download
+        return super(IRODSDownload, self)._download(file_path, rfile)
 
 
 class ExceptionIRODS(Exception):

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -75,7 +75,11 @@ class RSYNCDownload(DownloadInterface):
         if err_code != 0:
             self.logger.error('Error while downloading ' + rfile["name"] + ' - ' + str(err_code))
             error = True
-        return(error)
+        if error:
+            return error
+
+        # Our part is done so call parent _download
+        return super(RSYNCDownload, self)._download(file_path, rfile)
 
     def test_stderr_rsync_error(self, stderr):
         stderr = str(stderr.decode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ config = {
                          'pycurl',
                          'ftputil',
                          'tenacity',
-                         'simpeeval',
+                         'simpleeval',
                          'py-bcrypt',
                          'pika==0.13.0',
                          'redis',

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ config = {
                          'biomaj_zipkin',
                          'pycurl',
                          'ftputil',
+                         'tenacity',
+                         'simpeeval',
                          'py-bcrypt',
                          'pika==0.13.0',
                          'redis',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ config = {
     'download_url': 'http://biomaj.genouest.org',
     'author_email': 'olivier.sallou@irisa.fr',
     'version': '3.2.1',
-     'classifiers': [
+    'classifiers': [
         # How mature is this project? Common values are
         #   3 - Alpha
         #   4 - Beta

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ config = {
                          'protobuf',
                          'requests',
                          'humanfriendly',
-                         'python-irodsclient'
+                         'python-irodsclient',
+                         'six'
                         ],
     'tests_require': ['nose', 'mock'],
     'test_suite': 'nose.collector',

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -149,7 +149,7 @@ class UtilsForLocalIRODSTest(UtilsForTest):
     PORT = 1247
     ZONE = "tempZone"
     USER = "rods"
-    PASSWORD = "irods"
+    PASSWORD = "rods"
     COLLECTION = os.path.join("/" + ZONE, "home/rods/")  # Don't remove or add /
 
     def __init__(self):

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -633,7 +633,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
     ftpd.set_files_to_download([
           {'name': 'TOTO.zip', 'year': '2016', 'month': '02', 'day': '19',
            'size': 1, 'save_as': 'TOTO1KB'}
-    ])        
+    ])
     ftpd.set_options(dict(wait_condition=tenacity.wait.wait_fixed(3),
                           stop_condition=tenacity.stop.stop_after_attempt(n_attempts)))
     self.assertRaisesRegexp(
@@ -654,7 +654,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
     )
     self.assertTrue(len(ftpd.files_to_download) == 1)
     self.assertTrue(ftpd.retryer.statistics["attempt_number"] == n_attempts)
-    ftpd.close()  
+    ftpd.close()
 
   def test_ms_server(self):
       ftpd = CurlDownload("ftp", "test.rebex.net", "/")

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -195,20 +195,20 @@ class TestDownloadInterface(unittest.TestCase):
     d = dict(stop_condition="stop_after_attempts(5) & 1")  # not a stop_condition
     self.assertRaises(ValueError, downloader.set_options, d)
     # Test some garbage
-    d = dict(wait_condition="wait_random")  # no param
+    d = dict(wait_policy="wait_random")  # no param
     self.assertRaises(ValueError, downloader.set_options, d)
-    d = dict(wait_condition="I love python")  # not a wait_condition
+    d = dict(wait_policy="I love python")  # not a wait_condition
     self.assertRaises(ValueError, downloader.set_options, d)
-    d = dict(wait_condition="wait_random(5) + 3")  # not a wait_condition
+    d = dict(wait_policy="wait_random(5) + 3")  # not a wait_condition
     self.assertRaises(ValueError, downloader.set_options, d)
     # Test operators
     d = dict(stop_condition="stop_never | stop_after_attempt(5)",
-             wait_condition="wait_none + wait_random(1, 2)")
+             wait_policy="wait_none + wait_random(1, 2)")
     downloader.set_options(d)
     # Test wait_combine, wait_chain
-    d = dict(wait_condition="wait_combine(wait_fixed(3), wait_random(1, 2))")
+    d = dict(wait_policy="wait_combine(wait_fixed(3), wait_random(1, 2))")
     downloader.set_options(d)
-    d = dict(wait_condition="wait_chain(wait_fixed(3), wait_random(1, 2))")
+    d = dict(wait_policy="wait_chain(wait_fixed(3), wait_random(1, 2))")
     downloader.set_options(d)
     # Test stop_any and stop_all
     stop_condition = "stop_any(stop_after_attempt(5), stop_after_delay(10))"

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -671,8 +671,8 @@ class TestBiomajFTPDownload(unittest.TestCase):
           {'name': 'TOTO.zip', 'year': '2016', 'month': '02', 'day': '19',
            'size': 1, 'save_as': 'TOTO1KB'}
     ])
-    ftpd.set_options(dict(wait_condition=tenacity.wait.wait_fixed(3),
-                          stop_condition=tenacity.stop.stop_after_attempt(n_attempts)))
+    ftpd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
+                          wait_condition=tenacity.wait.wait_none()))
     self.assertRaisesRegexp(
         Exception, "^CurlDownload:Download:Error:",
         ftpd.download, self.utils.data_dir,
@@ -908,8 +908,8 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
               {'name': 'TOTO.zip', 'year': '2016', 'month': '02', 'day': '19',
                'size': 1, 'save_as': 'TOTO1KB'}
         ])
-        rsyncd.set_options(dict(wait_condition=tenacity.wait.wait_fixed(3),
-                                stop_condition=tenacity.stop.stop_after_attempt(n_attempts)))
+        rsyncd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
+                                wait_condition=tenacity.wait.wait_none()))
         self.assertRaisesRegexp(
             Exception, "^RSYNCDownload:Download:Error:",
             rsyncd.download, self.utils.data_dir,
@@ -1090,8 +1090,8 @@ class TestBiomajLocalIRODSDownload(unittest.TestCase):
               {'name': 'TOTO.zip', 'year': '2016', 'month': '02', 'day': '19',
                'size': 1, 'save_as': 'TOTO1KB'}
         ])
-        irodsd.set_options(dict(wait_condition=tenacity.wait.wait_fixed(3),
-                                stop_condition=tenacity.stop.stop_after_attempt(n_attempts)))
+        irodsd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
+                                wait_condition=tenacity.wait.wait_none()))
         self.assertRaisesRegexp(
             Exception, "^IRODSDownload:Download:Error:",
             irodsd.download, self.utils.data_dir,

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -190,12 +190,16 @@ class TestDownloadInterface(unittest.TestCase):
     # Test some garbage
     d = dict(stop_condition="stop_after_attempts")  # no param
     self.assertRaises(ValueError, downloader.set_options, d)
-    d = dict(stop_condition="1 + 1")  # not a stop_condition
+    d = dict(stop_condition="1 & 1")  # not a stop_condition
+    self.assertRaises(ValueError, downloader.set_options, d)
+    d = dict(stop_condition="stop_after_attempts(5) & 1")  # not a stop_condition
     self.assertRaises(ValueError, downloader.set_options, d)
     # Test some garbage
     d = dict(wait_condition="wait_random")  # no param
     self.assertRaises(ValueError, downloader.set_options, d)
-    d = dict(wait_condition="I love python")  # not a stop_condition
+    d = dict(wait_condition="I love python")  # not a wait_condition
+    self.assertRaises(ValueError, downloader.set_options, d)
+    d = dict(wait_condition="wait_random(5) + 3")  # not a wait_condition
     self.assertRaises(ValueError, downloader.set_options, d)
     # Test operators
     d = dict(stop_condition="stop_never | stop_after_attempt(5)",

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -30,7 +30,6 @@ import unittest
 import tenacity
 
 
-
 class UtilsForTest():
   """
   Copy properties files to a temp directory and update properties to


### PR DESCRIPTION
This PR creates a configurable mechanism to retry a download if it fails.

Previously, only downloaders based on `CurlDownloader` had such a mechanism which was rather simple (try a fixed number of time without any pause between attempts).

The new mechanism is based on the [tenacity module](https://github.com/jd/tenacity) which is designed for such purpose. This allows fine-grained control over how to wait between retries (for example use an exponential backoff sleeping between attempts) and when to stop (for example: try a certain number of times without exceeding a given amount of time). The implementation is generic (i.e. most of the work is done in `DownloaderInterface`) thanks to previous refactoring efforts.

The PR introduces 2 new options for downloaders:

- `wait_policy` to configure to wait between retries
- `stop_condition` to configure when to stop

The configuration of the options is based on the [simpleeval module](https://github.com/danthedeckie/simpleeval) which allows to parse strings like `stop_after_attempt(3) | stop_after_delay(5)` into tenacity objects. Default values for are added in 2 separate PR in the `biomaj-core` module: genouest/biomaj-core#6 and genouest/biomaj-core#7.

One of the side-effect of this is that we can factor the check of archives in `InterfaceDownload` so that all downloaders can use it (previously, only `CurlDownloader` did). See 098eb7c.

We considered being a bit smart on permanent errors i.e. don't retry when there is a way to check that it won't work for instance when the file doesn't exist or on FTP permanent errors. However, in our experience, so called permanent errors may well be temporary. Therefore downloaders always retry whatever the error. In some cases, this is a waste of time but generally this is worth it.

Status:

- most downloaders can use this mechanism (the only exception is `LocalDownloader` but failing to copy a local file probably indicates a larger problem); implemented and tested on `CurlDownload`, `RSYNCDownload` and `IRODSDownload`
- all stop conditions and wait policies are usable from configuration files
- basic tests: to test these functionality, we try to download non-existing files and check that it has been retried
- parsing tests: test that parsing from string works