### PR TITLE
Correctly detect iRODS exceptions and set error status.

### DIFF
--- a/biomaj_download/download/protocolirods.py
+++ b/biomaj_download/download/protocolirods.py
@@ -1,5 +1,6 @@
 from biomaj_download.download.interface import DownloadInterface
 from irods.session import iRODSSession
+from irods.exception import iRODSException
 from irods.models import DataObject, User
 
 
@@ -73,17 +74,10 @@ class IRODSDownload(DownloadInterface):
                 file_to_get = rfile['root'] + "/" + rfile['name']
             # Write the file to download in the wanted file_dir with the
             # python-irods iget
-            obj = session.data_objects.get(file_to_get, file_dir)
-        except ExceptionIRODS as e:
-            self.logger.error(self.__class__.__name__ + ":Download:Error:Can't get irods object " + str(obj))
-            self.logger.error(self.__class__.__name__ + ":Download:Error:" + str(e))
+            session.data_objects.get(file_to_get, file_dir)
+        except iRODSException as e:
+            error = True
+            self.logger.error(self.__class__.__name__ + ":Download:Error:Can't get irods object " + file_to_get)
+            self.logger.error(self.__class__.__name__ + ":Download:Error:" + repr(e))
         session.cleanup()
         return(error)
-
-
-class ExceptionIRODS(Exception):
-    def __init__(self, exception_reason):
-        self.exception_reason = exception_reason
-
-    def __str__(self):
-        return self.exception_reason


### PR DESCRIPTION
This PR corrects 2 bugs in IRODSDownload:

1. iRODS exception are not correctly detected (because the catch is based on the custom `ExceptionIRODS` class and not iRODS' exceptions).
2. the error status is not set in case of errors.

With those modifications trying to download a non-existent file (as below) is correctly detected (i.e. it raise a BioMAJ exception):
```
from biomaj_download.download.protocolirods import IRODSDownload

irodsd = IRODSDownload("localhost", "/tempZone/home/rods")
irodsd.set_options(dict(skip_check_uncompress=True))
irodsd.set_param(dict(
    user='rods',
    password='rods',
))
# Download a fake file
irodsd.set_files_to_download([
    {'name': 'TOTO.zip', 'year': 2016, 'month': 2, 'day': 19,
     'size': 1, 'save_as': 'TOTO1KB'}
])
irodsd.download("/tmp")
```
Without them, this code triggers iRODS errors.