### PR TITLE
Resolve bug of Rsync download 

### DIFF
--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -105,7 +105,7 @@ class RSYNCDownload(DownloadInterface):
             remote = str(self.server) + ":" + str(self.rootdir) + str(directory)
         if self.credentials:
             remote = str(self.credentials) + "@" + remote
-        cmd = str(self.real_protocol) + " --list-only " + remote
+        cmd = str(self.real_protocol) + " --list-only --no-motd " + remote
         try:
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             list_rsync, err = p.communicate()


### PR DESCRIPTION
This PR resolve a bug when a Message Of The Day exists at the connection. 

Indeed the parser try to parse the MOTD  and induce a IndexError: list index out of range. An add of the argument --no-mots is enough.                                                                                                                   