### PR TITLE
Speed up IRODDownload

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -183,7 +183,7 @@ class CurlDownload(DownloadInterface):
         # FTP method (cURL --ftp-method option)
         self.ftp_method = pycurl.FTPMETHOD_DEFAULT  # Use cURL default
 
-    def _basic_curl_configuration(self):
+    def _network_configuration(self):
         """
         Perform basic configuration (i.e. that doesn't depend on the
         operation: _download or list). This method should be called before any
@@ -304,8 +304,6 @@ class CurlDownload(DownloadInterface):
         file_url = self._file_url(rfile)
         while(error is True and nbtry < 3):
 
-            self._basic_curl_configuration()
-
             try:
                 self.crl.setopt(pycurl.URL, file_url)
             except Exception:
@@ -365,7 +363,7 @@ class CurlDownload(DownloadInterface):
         dir_url = self.url + self.rootdir + directory
         self.logger.debug('Download:List:' + dir_url)
 
-        self._basic_curl_configuration()
+        self._network_configuration()
 
         try:
             self.crl.setopt(pycurl.URL, dir_url)

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -86,7 +86,7 @@ class DirectFTPDownload(CurlDownload):
         '''
         FTP protocol does not give us the possibility to get file date from remote url
         '''
-        self._basic_curl_configuration()
+        self._network_configuration()
         for rfile in self.files_to_download:
             if self.save_as is None:
                 self.save_as = os.path.basename(rfile['name'])
@@ -148,7 +148,7 @@ class DirectHTTPDownload(DirectFTPDownload):
         '''
         Try to get file headers to get last_modification and size
         '''
-        self._basic_curl_configuration()
+        self._network_configuration()
         # Specific configuration
         self.crl.setopt(pycurl.HEADER, True)
         self.crl.setopt(pycurl.NOBODY, True)

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -314,6 +314,13 @@ class DownloadInterface(object):
         '''
         raise NotImplementedError()
 
+    def _network_configuration(self):
+        '''
+        Perform some configuration before network operations (list and
+        download). This must be implemented in subclasses.
+        '''
+        raise NotImplementedError()
+
     def download(self, local_dir, keep_dirs=True):
         '''
         Download remote files to local_dir
@@ -325,6 +332,7 @@ class DownloadInterface(object):
         :return: list of downloaded files
         '''
         self.logger.debug(self.__class__.__name__ + ':Download')
+        self._network_configuration()
         nb_files = len(self.files_to_download)
         cur_files = 1
         self.offline_dir = local_dir

--- a/biomaj_download/download/localcopy.py
+++ b/biomaj_download/download/localcopy.py
@@ -15,6 +15,9 @@ class LocalDownload(DownloadInterface):
     remote.dir=/blast/db/FASTA/
 
     remote.files=^alu.*\\.gz$
+
+    Note that we redefine download and list in such a way that we don't need to
+    define _download and _network_configuration.
     '''
 
     def __init__(self, rootdir, use_hardlinks=False):

--- a/biomaj_download/download/localcopy.py
+++ b/biomaj_download/download/localcopy.py
@@ -8,7 +8,7 @@ from biomaj_download.download.interface import DownloadInterface
 
 class LocalDownload(DownloadInterface):
     '''
-    Base class to copy file from local system
+    Base class to copy file from local system.
 
     protocol=cp
     server=localhost

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -53,6 +53,13 @@ class RSYNCDownload(DownloadInterface):
             url = self.server + ":" + url
         return url
 
+    def _network_configuration(self):
+        '''
+        Perform some configuration before network operations (list and
+        download).
+        '''
+        pass
+
     def _download(self, file_path, rfile):
         error = False
         err_code = ''


### PR DESCRIPTION
This PR introduces a new hook method `_network_configuration` which  is called  before network methods (`list` and `download`) to perform configuration (this generalizes `CurlDownload._basic_curl_configuration`).

This greatly speeds up the download of many files for IRODSDownloader (mainly because we don't cleanup and recreate the session after each download) and a bit for CurlDownloader (because less reconfiguration of the curl object).