### PR TITLE
Accept new keys for SFTP servers

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -11,6 +11,8 @@ import ftputil
 import humanfriendly
 
 from biomaj_core.utils import Utils
+from biomaj_core.config import BiomajConfig
+
 from biomaj_download.download.interface import DownloadInterface
 
 if sys.version_info[0] < 3:
@@ -120,6 +122,13 @@ class CurlDownload(DownloadInterface):
         "singlecwd": pycurl.FTPMETHOD_SINGLECWD,
     }
 
+    # Valid values for ssh_new_host options as string and int
+    VALID_SSH_NEW_HOST = {
+        "reject": pycurl.KHSTAT_REJECT,
+        "accept": pycurl.KHSTAT_FINE,
+        "add": pycurl.KHSTAT_FINE_ADD_TO_FILE,
+    }
+
     def __init__(self, curl_protocol, host, rootdir, http_parse=None):
         """
         Initialize a CurlDownloader.
@@ -181,6 +190,13 @@ class CurlDownload(DownloadInterface):
         self.tcp_keepalive = 0
         # FTP method (cURL --ftp-method option)
         self.ftp_method = pycurl.FTPMETHOD_DEFAULT  # Use cURL default
+        # known_hosts file
+        self.ssh_hosts_file = BiomajConfig.DEFAULTS["ssh_hosts_file"]
+        # How to treat unknown host
+        self.ssh_new_host = pycurl.KHSTAT_REJECT
+
+    def _accept_new_hosts(self, known_key, found_key, match):
+        return self.ssh_new_host
 
     def _network_configuration(self):
         """
@@ -198,6 +214,10 @@ class CurlDownload(DownloadInterface):
 
         if self.credentials is not None:
             self.crl.setopt(pycurl.USERPWD, self.credentials)
+
+        # Hosts file & function to decide for new hosts
+        self.crl.setopt(pycurl.SSH_KNOWNHOSTS, self.ssh_hosts_file)
+        self.crl.setopt(pycurl.SSH_KEYFUNCTION, self._accept_new_hosts)
 
         # Configure TCP keepalive
         if self.tcp_keepalive:
@@ -279,6 +299,13 @@ class CurlDownload(DownloadInterface):
             if raw_val not in self.VALID_FTP_FILEMETHOD:
                 raise ValueError("Invalid value for ftp_method")
             self.ftp_method = self.VALID_FTP_FILEMETHOD[raw_val]
+        if "ssh_hosts_file" in options:
+            self.ssh_hosts_file = options["ssh_hosts_file"]
+        if "ssh_new_host" in options:
+            raw_val = options["ssh_new_host"].lower()
+            if raw_val not in self.VALID_SSH_NEW_HOST:
+                raise ValueError("Invalid value for ssh_new_host")
+            self.ssh_new_host = self.VALID_SSH_NEW_HOST[raw_val]
 
     def _append_file_to_download(self, rfile):
         # Add url and root to the file if needed (for safety)

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -195,7 +195,7 @@ class CurlDownload(DownloadInterface):
         # How to treat unknown host
         self.ssh_new_host = self.VALID_SSH_NEW_HOST[BiomajConfig.DEFAULTS["ssh_new_host"]]
 
-    def _accept_new_hosts(self, known_key, found_key, match):
+    def _accept_new_hosts(self, known_keys, found_key, match):
         return self.ssh_new_host
 
     def _network_configuration(self):

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -193,7 +193,7 @@ class CurlDownload(DownloadInterface):
         # known_hosts file
         self.ssh_hosts_file = BiomajConfig.DEFAULTS["ssh_hosts_file"]
         # How to treat unknown host
-        self.ssh_new_host = pycurl.KHSTAT_REJECT
+        self.ssh_new_host = self.VALID_SSH_NEW_HOST[BiomajConfig.DEFAULTS["ssh_new_host"]]
 
     def _accept_new_hosts(self, known_key, found_key, match):
         return self.ssh_new_host

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -421,6 +421,8 @@ class TestBiomajSFTPDownload(unittest.TestCase):
 
   def setUp(self):
     self.utils = UtilsForTest()
+    # Temporary host key file in test dir (so this is claned)
+    (_, self.khfile) = tempfile.mkstemp(dir=self.utils.test_dir)
 
   def tearDown(self):
     self.utils.clean()
@@ -429,6 +431,7 @@ class TestBiomajSFTPDownload(unittest.TestCase):
     sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
     sftpd.set_credentials("demo:password")
     sftpd.set_options({
+        "ssh_hosts_file": self.khfile,
         "ssh_new_host": "add"
     })
     (file_list, dir_list) = sftpd.list()

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -428,6 +428,9 @@ class TestBiomajSFTPDownload(unittest.TestCase):
   def test_download(self):
     sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
     sftpd.set_credentials("demo:password")
+    sftpd.set_options({
+        "ssh_new_host": "add"
+    })
     (file_list, dir_list) = sftpd.list()
     sftpd.match([r'^readme.txt$'], file_list, dir_list)
     sftpd.download(self.utils.data_dir)


### PR DESCRIPTION
This PR adds the ability to use a custom known file and accept keys when using `SFTP`.

This is done by adding 2 new options for `CurlDownload`:

-  `ssh_hosts_file` which corresponds to [CURLOPT_SSH_KNOWNHOSTS](https://curl.haxx.se/libcurl/c/CURLOPT_SSH_KNOWNHOSTS.html) option
- `ssh_new_host` which allows to decide what to do for new hosts (using [CURLOPT_SSH_KEYFUNCTION](https://curl.haxx.se/libcurl/c/CURLOPT_SSH_KEYFUNCTION.html))

The goal is to handle #25.