### PR TITLE
Raise exceptions in method list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
-3.2.2
+3.2.3 [UNRELEASED]:
+
+3.2.2:
  #31 fix URL with multiple slashes
  Update demo password for ftps web site tests
  Remove python2 support

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@
  #31 fix URL with multiple slashes
  Update demo password for ftps web site tests
  Remove python2 support
+
 3.2.1:
  #26 Accept new keys for SFTP servers  (Closes #25)
  Strip extra slash characters in remote file list (due to regexp parsing)
@@ -11,43 +12,59 @@
  #24 Speed up IRODDownload
  Introduce a method to perform configuration before network methods. Adapt implementation of generic methods and subclasses.
  Resolve bug when the parser analyse also the Message Of The Day when it wants only list of file. (#23)
+
 3.1.2:
   #18 Add a protocol option to set CURLOPT_FTP_FILEMETHOD
   #19 Rename protocol options to options
   Fix copy of production files instead of download when files are in subdirectories
+
 3.1.1:
   #17 Support MDTM command in directftp
+
 3.1.0:
   #16 Don't change name after download in DirectHTTPDownloader
   PR #7 Refactor downloaders (*WARNING* breaks API)
+
 3.0.27:
   Fix previous release broken with a bug in direct protocols
+
 3.0.26:
   Change default download timeout to 1h
   #12 Allow FTPS protocol
   #14 Add mechanism for protocol specific options
+
 3.0.25:
   Allow to use hardlinks in LocalDownload
+
 3.0.24:
   Remove debug logs
+
 3.0.23:
   Support spaces in remote file names
+
 3.0.22:
   Fix **/* remote.files parsing
+
 3.0.21:
   Fix traefik labels
+
 3.0.20:
   Update pika dependency release
   Add tags for traefik support
+
 3.0.19:
   Check archives after download
   Fix python regexps syntax (deprecation)
+
 3.0.18:
   Rename protobuf and use specific package to avoid conflicts
+
 3.0.17:
   Regenerate protobuf message desc, failing on python3
+
 3.0.16:
   Add missing req in setup.py
+
 3.0.15:
   Fix progress download control where could have infinite loop
   Add irods download

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.2.3 [UNRELEASED]:
+  #30: raise errors when something in list() fail
 
 3.2.2:
   #31 fix URL with multiple slashes

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,17 +1,17 @@
 3.2.3 [UNRELEASED]:
 
 3.2.2:
- #31 fix URL with multiple slashes
- Update demo password for ftps web site tests
- Remove python2 support
+  #31 fix URL with multiple slashes
+  Update demo password for ftps web site tests
+  Remove python2 support
 
 3.2.1:
- #26 Accept new keys for SFTP servers  (Closes #25)
- Strip extra slash characters in remote file list (due to regexp parsing)
- #20 Add a configurable mechanism to retry download when it fails
- #24 Speed up IRODDownload
- Introduce a method to perform configuration before network methods. Adapt implementation of generic methods and subclasses.
- Resolve bug when the parser analyse also the Message Of The Day when it wants only list of file. (#23)
+  #26 Accept new keys for SFTP servers  (Closes #25)
+  Strip extra slash characters in remote file list (due to regexp parsing)
+  #20 Add a configurable mechanism to retry download when it fails
+  #24 Speed up IRODDownload
+  Introduce a method to perform configuration before network methods. Adapt implementation of generic methods and subclasses.
+  Resolve bug when the parser analyse also the Message Of The Day when it wants only list of file. (#23)
 
 3.1.2:
   #18 Add a protocol option to set CURLOPT_FTP_FILEMETHOD

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -159,15 +159,15 @@ class CurlDownload(DownloadInterface):
         if self.curl_protocol in self.FTP_PROTOCOL_FAMILY:
             self.protocol_family = "ftp"
             self._parse_result = self._ftp_parse_result
-            self.ERRCODE_OK = 226
+            self.ERRCODE_OK = [221, 226]
         elif self.curl_protocol in self.HTTP_PROTOCOL_FAMILY:
             self.protocol_family = "http"
             self._parse_result = self._http_parse_result
-            self.ERRCODE_OK = 200
+            self.ERRCODE_OK = [200]
         elif self.curl_protocol in self.SFTP_PROTOCOL_FAMILY:
             self.protocol_family = "sftp"
             self._parse_result = self._ftp_parse_result
-            self.ERRCODE_OK = 0
+            self.ERRCODE_OK = [0]
         else:  # Should not happen since we check before
             raise ValueError("Unknown protocol")
         self.rootdir = rootdir
@@ -368,7 +368,7 @@ class CurlDownload(DownloadInterface):
         try:
             self.crl.perform()
             errcode = self.crl.getinfo(pycurl.RESPONSE_CODE)
-            if int(errcode) != self.ERRCODE_OK:
+            if int(errcode) not in self.ERRCODE_OK:
                 error = True
                 self.logger.error('Error while downloading ' + file_url + ' - ' + str(errcode))
             else:
@@ -413,7 +413,7 @@ class CurlDownload(DownloadInterface):
         try:
             self.crl.perform()
             errcode = self.crl.getinfo(pycurl.RESPONSE_CODE)
-            if int(errcode) != self.ERRCODE_OK:
+            if int(errcode) not in self.ERRCODE_OK:
                 msg = 'Error while listing ' + dir_url + ' - ' + str(errcode)
                 self.logger.error(msg)
                 raise Exception(msg)

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -407,8 +407,15 @@ class CurlDownload(DownloadInterface):
         # Try to list
         try:
             self.crl.perform()
+            errcode = self.crl.getinfo(pycurl.RESPONSE_CODE)
+            if int(errcode) != self.ERRCODE_OK:
+                msg = 'Error while listing ' + dir_url + ' - ' + str(errcode)
+                self.logger.error(msg)
+                raise Exception(msg)
         except Exception as e:
-            self.logger.error('Could not get errcode:' + str(e))
+            msg = 'Error while listing ' + dir_url + ' - ' + str(e)
+            self.logger.error(msg)
+            raise e
 
         # Figure out what encoding was sent with the response, if any.
         # Check against lowercased header name.

--- a/biomaj_download/download/localcopy.py
+++ b/biomaj_download/download/localcopy.py
@@ -60,7 +60,12 @@ class LocalDownload(DownloadInterface):
         rfiles = []
         rdirs = []
 
-        files = [f for f in os.listdir(self.rootdir + directory)]
+        try:
+            files = [f for f in os.listdir(self.rootdir + directory)]
+        except Exception as e:
+            msg = 'Error while listing ' + self.rootdir + ' - ' + str(e)
+            self.logger.error(msg)
+            raise e
         for file_in_files in files:
             rfile = {}
             fstat = os.stat(os.path.join(self.rootdir + directory, file_in_files))

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -33,12 +33,6 @@ class RSYNCDownload(DownloadInterface):
         else:
             self.server = None
             self.rootdir = server
-        # give a working directory to run rsync
-        if self.local_mode:
-            try:
-                os.chdir(self.rootdir)
-            except TypeError:
-                self.logger.error("RSYNC:Could not find local dir " + self.rootdir)
 
     def _append_file_to_download(self, rfile):
         if 'root' not in rfile or not rfile['root']:

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -2,7 +2,6 @@
 # standard_library.install_aliases()
 # from builtins import str
 import re
-import os
 import subprocess
 
 from biomaj_download.download.interface import DownloadInterface

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -120,8 +120,9 @@ class RSYNCDownload(DownloadInterface):
         except ExceptionRsync as e:
             self.logger.error("RsyncError:" + str(e))
         if err_code != 0:
-            self.logger.error('Error while listing ' + str(err_code))
-            return(rfiles, rdirs)
+            msg = 'Error while listing ' + remote + ' - ' + str(err_code)
+            self.logger.error(msg)
+            raise Exception(msg)
         list_rsync = str(list_rsync.decode('utf-8'))
         lines = list_rsync.rstrip().split("\n")
         for line in lines:

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -892,7 +892,7 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     ftpd.close()
     self.assertTrue(len(ftpd.files_to_download) == 1)
 
-  def test_download_ssl_certficate(self):
+  def test_download_ssl_certificate(self):
     # This server is misconfigured but we use its certificate
     # The hostname is wrong so we disable host verification
     SERVER = "demo.wftpserver.com"

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -242,6 +242,16 @@ class TestBiomajLocalDownload(unittest.TestCase):
     locald.close()
     self.assertTrue(len(file_list) > 1)
 
+  def test_local_list(self):
+    locald = LocalDownload("/tmp/foo/")
+    (file_list, dir_list) = locald.list()
+    # Check that we raise an exception and log a message
+     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+       with self.assertRaises(Exception):
+         (file_list, dir_list) = locald.list()
+         self.assertRegexp(cm.output, "^Error while listing")
+    locald.close()
+
   def test_local_download(self):
     locald = LocalDownload(self.examples)
     (file_list, dir_list) = locald.list()
@@ -312,6 +322,18 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     (file_list, dir_list) = httpd.list()
     httpd.close()
     self.assertTrue(len(file_list) == 1)
+
+  def test_http_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/foo/', self.http_parse)
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = httpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
 
   def test_http_list_dateregexp(self):
     #self.http_parse.file_date_format = "%%d-%%b-%%Y %%H:%%M"
@@ -426,6 +448,29 @@ class TestBiomajSFTPDownload(unittest.TestCase):
 
   def tearDown(self):
     self.utils.clean()
+
+  def test_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/toto")
+    sftpd.set_credentials("demo:password")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = sftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    sftpd.close()
+    # Test with wrong password
+    sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
+    sftpd.set_credentials("demo:badpassword")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = sftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    sftpd.close()
 
   def test_download(self):
     sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
@@ -603,6 +648,29 @@ class TestBiomajFTPDownload(unittest.TestCase):
     ftpd.close()
     self.assertTrue(len(file_list) > 1)
 
+  def test_ftp_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    ftpd = CurlDownload("ftp", "test.rebex.net", "/toto")
+    ftpd.set_credentials("demo:password")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
+    # Test with wrong password
+    ftpd = CurlDownload("ftp", "test.rebex.net", "/")
+    ftpd.set_credentials("demo:badpassword")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
+
   @attr('test')
   def test_download(self):
     ftpd = CurlDownload('ftp', 'speedtest.tele2.net', '/')
@@ -766,6 +834,29 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     ftpd.close()
     self.assertTrue(len(file_list) == 1)
 
+  def test_ftps_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    ftpd = CurlDownload("ftps", "test.rebex.net", "/toto")
+    ftpd.set_credentials("demo:password")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
+    # Test with wrong password
+    ftpd = CurlDownload("ftps", "test.rebex.net", "/")
+    ftpd.set_credentials("demo:badpassword")
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
+
   def test_download(self):
     ftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
     ftpd.set_credentials("demo:password")
@@ -839,6 +930,17 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
         rsyncd = RSYNCDownload(self.examples, "")
         (files_list, dir_list) = rsyncd.list()
         self.assertTrue(len(files_list) != 0)
+
+    def test_rsync_list_error(self):
+        # Access a non-existent directory
+        rsyncd = RSYNCDownload("/tmp/foo/", "")
+        (files_list, dir_list) = rsyncd.list()
+        self.assertTrue(len(files_list) != 0)
+        # Check that we raise an exception and log a message
+        with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+            with self.assertRaises(Exception):
+                (file_list, dir_list) = rsyncd.list()
+                self.assertRegexp(cm.output, "^Error while listing")
 
     def test_rsync_match(self):
         rsyncd = RSYNCDownload(self.examples, "")

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -242,14 +242,14 @@ class TestBiomajLocalDownload(unittest.TestCase):
     locald.close()
     self.assertTrue(len(file_list) > 1)
 
-  def test_local_list(self):
+  def test_local_list_error(self):
     locald = LocalDownload("/tmp/foo/")
     (file_list, dir_list) = locald.list()
     # Check that we raise an exception and log a message
-     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
-       with self.assertRaises(Exception):
-         (file_list, dir_list) = locald.list()
-         self.assertRegexp(cm.output, "^Error while listing")
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = locald.list()
+        self.assertRegexp(cm.output, "^Error while listing")
     locald.close()
 
   def test_local_download(self):

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -506,6 +506,21 @@ class TestBiomajDirectFTPDownload(unittest.TestCase):
     ftpd.close()
     self.assertTrue(len(file_list) == 1)
 
+  def test_ftp_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    file_list = ['/toto/debian/doc/mailing-lists.txt']
+    ftpd = DirectFTPDownload('ftp', 'ftp.fr.debian.org', '')
+    ftpd.set_files_to_download(file_list)
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
+
   def test_download(self):
     file_list = ['/debian/doc/mailing-lists.txt']
     ftpd = DirectFTPDownload('ftp', 'ftp.fr.debian.org', '')
@@ -574,6 +589,21 @@ class TestBiomajDirectHTTPDownload(unittest.TestCase):
     self.assertTrue(len(file_list) == 1)
     self.assertTrue(file_list[0]['size']!=0)
     self.assertFalse(fyear == ftpd.files_to_download[0]['year'] and fmonth == ftpd.files_to_download[0]['month'] and fday == ftpd.files_to_download[0]['day'])
+
+  def test_http_list_error(self):
+    """
+    Test that errors in list are correctly caught.
+    """
+    # Test access to non-existent directory
+    file_list = ['/toto/debian/README.html']
+    ftpd = DirectHTTPDownload('http', 'ftp2.fr.debian.org', '')
+    ftpd.set_files_to_download(file_list)
+    # Check that we raise an exception and log a message
+    with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+      with self.assertRaises(Exception):
+        (file_list, dir_list) = ftpd.list()
+        self.assertRegexp(cm.output, "^Error while listing")
+    ftpd.close()
 
   def test_download(self):
     file_list = ['/debian/README.html']

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -244,7 +244,6 @@ class TestBiomajLocalDownload(unittest.TestCase):
 
   def test_local_list_error(self):
     locald = LocalDownload("/tmp/foo/")
-    (file_list, dir_list) = locald.list()
     # Check that we raise an exception and log a message
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
@@ -934,8 +933,6 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
     def test_rsync_list_error(self):
         # Access a non-existent directory
         rsyncd = RSYNCDownload("/tmp/foo/", "")
-        (files_list, dir_list) = rsyncd.list()
-        self.assertTrue(len(files_list) != 0)
         # Check that we raise an exception and log a message
         with self.assertLogs(logger="biomaj", level="ERROR") as cm:
             with self.assertRaises(Exception):

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -708,13 +708,13 @@ class TestBiomajFTPDownload(unittest.TestCase):
     ftpd.close()
 
   def test_ms_server(self):
-      ftpd = CurlDownload("ftp", "test.rebex.net", "/")
-      ftpd.set_credentials("demo:password")
-      (file_list, dir_list) = ftpd.list()
-      ftpd.match(["^readme.txt$"], file_list, dir_list)
-      ftpd.download(self.utils.data_dir)
-      ftpd.close()
-      self.assertTrue(len(ftpd.files_to_download) == 1)
+    ftpd = CurlDownload("ftp", "test.rebex.net", "/")
+    ftpd.set_credentials("demo:password")
+    (file_list, dir_list) = ftpd.list()
+    ftpd.match(["^readme.txt$"], file_list, dir_list)
+    ftpd.download(self.utils.data_dir)
+    ftpd.close()
+    self.assertTrue(len(ftpd.files_to_download) == 1)
 
   def test_download_tcp_keepalive(self):
       """


### PR DESCRIPTION
This PR addresses issue #29. This is mainly raising errors when something goes wrong on `list`.

There are 2 changes that could impact other aspects :

   -  when listing `FTPS(S)` servers, `cURL` issues  a `QUIT` command; then `RESPONSE_CODE` is `221` instead of `226`. 6d809f2 implements a list of accepted codes (instead of a single one). Note that for `FTP(S)`, `cURL` usually raises an exception so checking `RESPONSE_CODE` is not really needed. However, it doesn't raise an exception for `404` errors when using `HTTP` (the option [CURLOPT_FAILONERROR](https://curl.haxx.se/libcurl/c/CURLOPT_FAILONERROR.html) could help but it's not perfect). So using a list of `RESPONSE_CODE` is simpler.
  - `RSYNCDownload` no longer `chidr` in constructor (see b68bb74). This was a check (as passing a local, non-existent directory would then raise an exception) but I was not sure if this was compatible in particular with microservices (what happen if we can't construct the downloader ? could changing the current directory affect other process, downloaders, etc. ?). According to our tests, this doesn't affect where files are downloaded.

Functional tests are done in genouest/biomaj#120.

Note that the tests use [assertLogs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertLogs) which requires python >= 3.4 so we needed to drop support for python 2 before (see afefe2d).