### PR TITLE
Clean HTTPPparse in tests

### DIFF
--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -390,19 +390,17 @@ class TestBiomajHTTPSDownload(unittest.TestCase):
     self.utils.clean()
 
   def test_download(self):
-    self.utils = UtilsForTest()
-    self.http_parse = HTTPParse(
+    http_parse = HTTPParse(
         "<a[\s]+href=\"([\w\-\.]+\">[\w\-\.]+.tar.gz)<\/a>[\s]+([0-9]{2}-[A-Za-z]{3}-[0-9]{4}[\s][0-9]{2}:[0-9]{2})[\s]+([0-9]+[A-Za-z])",
         "<a[\s]+href=\"[\w\-\.]+\">([\w\-\.]+.tar.gz)<\/a>[\s]+([0-9]{2}-[A-Za-z]{3}-[0-9]{4}[\s][0-9]{2}:[0-9]{2})[\s]+([0-9]+[A-Za-z])",
         1,
         2,
         1,
         2,
-        None,
+        "%%d-%%b-%%Y %%H:%%M",
         3
     )
-    self.http_parse.file_date_format = "%%d-%%b-%%Y %%H:%%M"
-    httpd = CurlDownload('https', 'mirrors.edge.kernel.org', '/pub/software/scm/git/debian/', self.http_parse)
+    httpd = CurlDownload('https', 'mirrors.edge.kernel.org', '/pub/software/scm/git/debian/', http_parse)
     (file_list, dir_list) = httpd.list()
     httpd.match([r'^git-core-0.99.6.tar.gz$'], file_list, dir_list)
     httpd.download(self.utils.data_dir)

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -293,14 +293,16 @@ class TestBiomajHTTPDownload(unittest.TestCase):
   def setUp(self):
     self.utils = UtilsForTest()
     BiomajConfig.load_config(self.utils.global_properties, allow_user_config=False)
+    # Create an HTTPParse object used for most tests from the config file testhttp
     self.config = BiomajConfig('testhttp')
-    self.http_parse = HTTPParse(self.config.get('http.parse.dir.line'),
+    self.http_parse = HTTPParse(
+        self.config.get('http.parse.dir.line'),
         self.config.get('http.parse.file.line'),
         int(self.config.get('http.group.dir.name')),
         int(self.config.get('http.group.dir.date')),
         int(self.config.get('http.group.file.name')),
         int(self.config.get('http.group.file.date')),
-        self.config.get('http.group.file.date_format', None),
+        self.config.get('http.group.file.date_format'),
         int(self.config.get('http.group.file.size'))
     )
 
@@ -314,25 +316,23 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     self.assertTrue(len(file_list) == 1)
 
   def test_http_list_dateregexp(self):
-    #self.http_parse.file_date_format = "%%d-%%b-%%Y %%H:%%M"
-    self.http_parse.file_date_format = "%%Y-%%m-%%d %%H:%%M"
     httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
     (file_list, dir_list) = httpd.list()
     httpd.close()
     self.assertTrue(len(file_list) == 1)
 
   def test_http_download_no_size(self):
-    self.http_parse = HTTPParse(self.config.get('http.parse.dir.line'),
+    # Create a custom http_parse without size
+    http_parse = HTTPParse(self.config.get('http.parse.dir.line'),
         self.config.get('http.parse.file.line'),
         int(self.config.get('http.group.dir.name')),
         int(self.config.get('http.group.dir.date')),
         int(self.config.get('http.group.file.name')),
         int(self.config.get('http.group.file.date')),
-        self.config.get('http.group.file.date_format', None),
+        self.config.get('http.group.file.date_format'),
         -1
     )
-    self.http_parse.file_date_format = "%%Y-%%m-%%d %%H:%%M"
-    httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
+    httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', http_parse)
     (file_list, dir_list) = httpd.list()
     httpd.match([r'^README$'], file_list, dir_list)
     httpd.download(self.utils.data_dir)
@@ -340,16 +340,17 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     self.assertTrue(len(httpd.files_to_download) == 1)
 
   def test_http_download_no_date(self):
-    self.http_parse = HTTPParse(self.config.get('http.parse.dir.line'),
+    # Create a custom http_parse without date
+    http_parse = HTTPParse(self.config.get('http.parse.dir.line'),
         self.config.get('http.parse.file.line'),
         int(self.config.get('http.group.dir.name')),
         int(self.config.get('http.group.dir.date')),
         int(self.config.get('http.group.file.name')),
         -1,
-        self.config.get('http.group.file.date_format', None),
+        None,
         int(self.config.get('http.group.file.size'))
     )
-    httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
+    httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', http_parse)
     (file_list, dir_list) = httpd.list()
     httpd.match([r'^README$'], file_list, dir_list)
     httpd.download(self.utils.data_dir)
@@ -357,7 +358,6 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     self.assertTrue(len(httpd.files_to_download) == 1)
 
   def test_http_download(self):
-    self.http_parse.file_date_format = "%%Y-%%m-%%d %%H:%%M"
     httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
     (file_list, dir_list) = httpd.list()
     print(str(file_list))
@@ -367,7 +367,6 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     self.assertTrue(len(httpd.files_to_download) == 1)
 
   def test_http_download_in_subdir(self):
-    self.http_parse.file_date_format = "%%Y-%%m-%%d %%H:%%M"
     httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/', self.http_parse)
     (file_list, dir_list) = httpd.list()
     httpd.match([r'^dists/README$'], file_list, dir_list)

--- a/tests/testhttp.properties
+++ b/tests/testhttp.properties
@@ -38,7 +38,7 @@ db.post.process=
 
 http.parse.dir.line=<img[\s]+src="[\S]+"[\s]+alt="\[DIR\]"?.*<a[\s]+href="([\S]+)\/"[\s]*>.*([\d]{4}-[\w\d]{2,5}-[\d]{2}\s[\d]{2}:[\d]{2})
 http.parse.file.line=<img[\s]+src="[\S]+"[\s]+alt="\[[\s]+\]"[\s]*\/?><\/td><td><a[\s]+href="([\S]+)".*([\d]{4}-[\d]{2}-[\d]{2}\s[\d]{2}:[\d]{2}).*>([\d\.]+[MKG]{0,1})
-http.group.file.date_format="%%Y-%%m-%%d %%H:%%M"
+http.group.file.date_format=%%Y-%%m-%%d %%H:%%M
 ### Deployment ###
 
 keep.old.version=1


### PR DESCRIPTION
The usage of `HTTPParse` in class `TestBiomajHTTPDownload` (and a bit in `TestBiomajHTTPSDownload`) is messy:

- `setUp` creates an `HTTPParse` object (`self.http_parse`) used in most tests but some tests recreate or modify it. The usage of `date_format` is weird.
- The value of `date_format` in the config file contains quotes which seems wrong (and may explain why `date_format` is set several times for no apparent reason).

This PR cleans the situation:

- The common `self.http_parse` is created once and not modified and the value of `date_format` is correct.
- Tests that need a custom `HTTPParse` create it (using the value in the config file if possible). 

We also clean some useless code.