### PR TITLE
Remove some python2 compatibility code, imports and dependencies

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -1,9 +1,10 @@
-import sys
 import re
 from datetime import datetime
 import hashlib
 import time
 import stat
+from urllib.parse import urlencode
+from io import BytesIO
 
 import pycurl
 import ftputil
@@ -14,58 +15,6 @@ from biomaj_core.utils import Utils
 from biomaj_core.config import BiomajConfig
 
 from biomaj_download.download.interface import DownloadInterface
-
-if sys.version_info[0] < 3:
-    from urllib import urlencode
-else:
-    from urllib.parse import urlencode
-
-try:
-    from io import BytesIO
-except ImportError:
-    from StringIO import StringIO as BytesIO
-
-# We use stat.filemode to convert from mode octal value to string.
-# In python < 3.3, stat.filmode is not defined.
-# This code is copied from the current implementation of stat.filemode.
-if 'filemode' not in stat.__dict__:
-    _filemode_table = (
-        ((stat.S_IFLNK,                "l"),    # noqa: E241
-         (stat.S_IFREG,                "-"),    # noqa: E241
-         (stat.S_IFBLK,                "b"),    # noqa: E241
-         (stat.S_IFDIR,                "d"),    # noqa: E241
-         (stat.S_IFCHR,                "c"),    # noqa: E241
-         (stat.S_IFIFO,                "p")),   # noqa: E241
-        ((stat.S_IRUSR,                "r"),),  # noqa: E241
-        ((stat.S_IWUSR,                "w"),),  # noqa: E241
-        ((stat.S_IXUSR | stat.S_ISUID, "s"),    # noqa: E241
-         (stat.S_ISUID,                "S"),    # noqa: E241
-         (stat.S_IXUSR,                "x")),   # noqa: E241
-        ((stat.S_IRGRP,                "r"),),  # noqa: E241
-        ((stat.S_IWGRP,                "w"),),  # noqa: E241
-        ((stat.S_IXGRP | stat.S_ISGID, "s"),    # noqa: E241
-         (stat.S_ISGID,                "S"),    # noqa: E241
-         (stat.S_IXGRP,                "x")),   # noqa: E241
-        ((stat.S_IROTH,                "r"),),  # noqa: E241
-        ((stat.S_IWOTH,                "w"),),  # noqa: E241
-        ((stat.S_IXOTH | stat.S_ISVTX, "t"),    # noqa: E241
-         (stat.S_ISVTX,                "T"),    # noqa: E241
-         (stat.S_IXOTH,                "x"))    # noqa: E241
-    )
-
-    def _filemode(mode):
-        """Convert a file's mode to a string of the form '-rwxrwxrwx'."""
-        perm = []
-        for table in _filemode_table:
-            for bit, char in table:
-                if mode & bit == bit:
-                    perm.append(char)
-                    break
-            else:
-                perm.append("-")
-        return "".join(perm)
-
-    stat.filemode = _filemode
 
 
 class HTTPParse(object):

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -21,21 +21,12 @@ import datetime
 import pycurl
 import re
 import hashlib
-import sys
 import os
+from urllib.parse import urlencode
+from io import BytesIO
 
 from biomaj_download.download.curl import CurlDownload
 from biomaj_core.utils import Utils
-
-if sys.version_info[0] < 3:
-    from urllib import urlencode
-else:
-    from urllib.parse import urlencode
-
-try:
-    from io import BytesIO
-except ImportError:
-    from StringIO import StringIO as BytesIO
 
 
 class DirectFTPDownload(CurlDownload):

--- a/biomaj_download/download/interface.py
+++ b/biomaj_download/download/interface.py
@@ -5,8 +5,6 @@ import time
 import re
 import copy
 
-import six
-
 import tenacity
 from simpleeval import simple_eval, ast
 
@@ -254,7 +252,7 @@ class DownloadInterface(object):
         if isinstance(stop_condition, tenacity.stop.stop_base):
             # Use the value directly
             stop_cond = stop_condition
-        elif isinstance(stop_condition, six.string_types):
+        elif isinstance(stop_condition, str):
             # Try to parse the string
             try:
                 stop_cond = simple_eval(stop_condition,
@@ -280,7 +278,7 @@ class DownloadInterface(object):
         if isinstance(wait_policy, tenacity.wait.wait_base):
             # Use the value directly
             wait_pol = wait_policy
-        elif isinstance(wait_policy, six.string_types):
+        elif isinstance(wait_policy, str):
             # Try to parse the string
             try:
                 wait_pol = simple_eval(wait_policy,

--- a/biomaj_download/downloadclient.py
+++ b/biomaj_download/downloadclient.py
@@ -3,16 +3,12 @@ import requests
 import logging
 import uuid
 import time
-import sys
+from queue import Queue
+
 import pika
 
 from biomaj_download.download.downloadthreads import DownloadThread
 from biomaj_download.message import downmessage_pb2
-
-if sys.version_info[0] < 3:
-    from Queue import Queue
-else:
-    from queue import Queue
 
 
 class DownloadClient(DownloadService):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ biomaj_zipkin
 flake8
 humanfriendly
 python-irodsclient
-six
 simpleeval
 tenacity

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,7 @@ config = {
                          'protobuf',
                          'requests',
                          'humanfriendly',
-                         'python-irodsclient',
-                         'six'
+                         'python-irodsclient'
                         ],
     'tests_require': ['nose', 'mock'],
     'test_suite': 'nose.collector',


### PR DESCRIPTION
As python2 is no longer used, this PR removes some dependencies, imports and code needed to run on both python2 and python3.

Changes in the code are minor:

- import compatibility
- dropping `six` implies minor modifications
- removal of `stat.filemode` backported from python 3.4