### PR TITLE
Correct PR #30

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -108,7 +108,7 @@ class CurlDownload(DownloadInterface):
         if self.curl_protocol in self.FTP_PROTOCOL_FAMILY:
             self.protocol_family = "ftp"
             self._parse_result = self._ftp_parse_result
-            self.ERRCODE_OK = [221, 226, 350]
+            self.ERRCODE_OK = [221, 226]
         elif self.curl_protocol in self.HTTP_PROTOCOL_FAMILY:
             self.protocol_family = "http"
             self._parse_result = self._http_parse_result

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -178,8 +178,8 @@ class DirectHTTPDownload(DirectFTPDownload):
                 self.crl.perform()
                 errcode = int(self.crl.getinfo(pycurl.RESPONSE_CODE))
                 if errcode == 405:  # HEAD not supported
-                  msg = 'Listing ' + file_url + ' not supported. This is fine, continuing.'
-                  self.logger.info(msg)
+                    msg = 'Listing ' + file_url + ' not supported. This is fine, continuing.'
+                    self.logger.info(msg)
                 elif errcode not in self.ERRCODE_OK:
                     msg = 'Error while listing ' + file_url + ' - ' + str(errcode)
                     self.logger.error(msg)

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -104,7 +104,7 @@ class DirectFTPDownload(CurlDownload):
             # download the file).
             try:
                 self.crl.perform()
-                errcode = int(self.crl.getinfo(pycurl.RESPONSE_CODE))      
+                errcode = int(self.crl.getinfo(pycurl.RESPONSE_CODE))
                 if errcode != 350 and errcode not in self.ERRCODE_OK:
                     msg = 'Error while listing ' + file_url + ' - ' + str(errcode)
                     self.logger.error(msg)

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -156,12 +156,12 @@ class DirectHTTPDownload(DirectFTPDownload):
         self._network_configuration()
         # Specific configuration
         # With those options, cURL will issue a HEAD request. This may not be
-        # supported especially resources that are accessed using POST (HTTP
-        # return code 405). Therefore, we explicitely handle this case in this
-        # method.
-        # Note that in many cases, there is no Last-Modified field in headers
-        # since this is usually dynamic content (Content-Length is usually
-        # present).
+        # supported especially on resources that are accessed using POST. In
+        # this case, HTTP will return code 405. We explicitely handle this case
+        # in this method.
+        # Note also that in many cases, there is no Last-Modified field in
+        # headers since this is usually dynamic content (Content-Length is
+        # usually present).
         self.crl.setopt(pycurl.HEADER, True)
         self.crl.setopt(pycurl.NOBODY, True)
         for rfile in self.files_to_download:
@@ -183,7 +183,10 @@ class DirectHTTPDownload(DirectFTPDownload):
             try:
                 self.crl.perform()
                 errcode = int(self.crl.getinfo(pycurl.RESPONSE_CODE))
-                if errcode == 405:  # HEAD not supported by the server for this URL.
+                if errcode == 405:
+                    # HEAD not supported by the server for this URL so we can
+                    # skip the rest of the loop (we won't have metadata about
+                    # the file but biomaj should be fine).
                     msg = 'Listing ' + file_url + ' not supported. This is fine, continuing.'
                     self.logger.info(msg)
                     continue

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -155,13 +155,13 @@ class DirectHTTPDownload(DirectFTPDownload):
         '''
         self._network_configuration()
         # Specific configuration
-        # With those options, cURL will issue a HEAD request. Note this may
-        # not be supported especially reousrces that are accessed using POST.
-        # Therefore, we explicitely handle this case (HTTP reutrn code 405)
-        # here.
-        # Note that in many cases (even with HEAD), there is no Last-Modified
-        # date in headers (Content-Length is usually present) since this is
-        # usually dynamic content.
+        # With those options, cURL will issue a HEAD request. This may not be
+        # supported especially resources that are accessed using POST (HTTP
+        # return code 405). Therefore, we explicitely handle this case in this
+        # method.
+        # Note that in many cases, there is no Last-Modified field in headers
+        # since this is usually dynamic content (Content-Length is usually
+        # present).
         self.crl.setopt(pycurl.HEADER, True)
         self.crl.setopt(pycurl.NOBODY, True)
         for rfile in self.files_to_download:
@@ -183,7 +183,7 @@ class DirectHTTPDownload(DirectFTPDownload):
             try:
                 self.crl.perform()
                 errcode = int(self.crl.getinfo(pycurl.RESPONSE_CODE))
-                if errcode == 405:  # HEAD not supported by the server.
+                if errcode == 405:  # HEAD not supported by the server for this URL.
                     msg = 'Listing ' + file_url + ' not supported. This is fine, continuing.'
                     self.logger.info(msg)
                 elif errcode not in self.ERRCODE_OK:

--- a/biomaj_download/download/direct.py
+++ b/biomaj_download/download/direct.py
@@ -186,6 +186,7 @@ class DirectHTTPDownload(DirectFTPDownload):
                 if errcode == 405:  # HEAD not supported by the server for this URL.
                     msg = 'Listing ' + file_url + ' not supported. This is fine, continuing.'
                     self.logger.info(msg)
+                    continue
                 elif errcode not in self.ERRCODE_OK:
                     msg = 'Error while listing ' + file_url + ' - ' + str(errcode)
                     self.logger.error(msg)

--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -116,12 +116,14 @@ class RSYNCDownload(DownloadInterface):
             self.test_stderr_rsync_message(err)
             self.test_stderr_rsync_error(err)
             err_code = p.returncode
+            if err_code != 0:
+                msg = 'Error while listing ' + remote + ' - ' + str(err_code)
+                self.logger.error(msg)
+                raise Exception(msg)
         except ExceptionRsync as e:
-            self.logger.error("RsyncError:" + str(e))
-        if err_code != 0:
-            msg = 'Error while listing ' + remote + ' - ' + str(err_code)
+            msg = 'Error while listing ' + remote + ' - ' + str(e)
             self.logger.error(msg)
-            raise Exception(msg)
+            raise e
         list_rsync = str(list_rsync.decode('utf-8'))
         lines = list_rsync.rstrip().split("\n")
         for line in lines:

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -248,7 +248,7 @@ class TestBiomajLocalDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = locald.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     locald.close()
 
   def test_local_download(self):
@@ -334,7 +334,7 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = httpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
 
   def test_http_list_dateregexp(self):
     httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
@@ -456,7 +456,7 @@ class TestBiomajSFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = sftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     sftpd.close()
     # Test with wrong password
     sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
@@ -465,7 +465,7 @@ class TestBiomajSFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = sftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     sftpd.close()
 
   def test_download(self):
@@ -515,7 +515,7 @@ class TestBiomajDirectFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -599,7 +599,7 @@ class TestBiomajDirectHTTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -685,7 +685,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
     # Test with wrong password
     ftpd = CurlDownload("ftp", "test.rebex.net", "/")
@@ -694,7 +694,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
 
   @attr('test')
@@ -964,7 +964,7 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
         with self.assertLogs(logger="biomaj", level="ERROR") as cm:
             with self.assertRaises(Exception):
                 (file_list, dir_list) = rsyncd.list()
-                self.assertRegexp(cm.output, "^Error while listing")
+                self.assertRegex(cm.output, "^Error while listing")
 
     def test_rsync_match(self):
         rsyncd = RSYNCDownload(self.examples, "")

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -248,7 +248,8 @@ class TestBiomajLocalDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = locald.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     locald.close()
 
   def test_local_download(self):
@@ -334,7 +335,8 @@ class TestBiomajHTTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = httpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
 
   def test_http_list_dateregexp(self):
     httpd = CurlDownload('http', 'ftp2.fr.debian.org', '/debian/dists/', self.http_parse)
@@ -456,7 +458,8 @@ class TestBiomajSFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = sftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     sftpd.close()
     # Test with wrong password
     sftpd = CurlDownload(self.PROTOCOL, "test.rebex.net", "/")
@@ -465,7 +468,8 @@ class TestBiomajSFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = sftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     sftpd.close()
 
   def test_download(self):
@@ -515,7 +519,8 @@ class TestBiomajDirectFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -599,7 +604,8 @@ class TestBiomajDirectHTTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -685,7 +691,8 @@ class TestBiomajFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
     # Test with wrong password
     ftpd = CurlDownload("ftp", "test.rebex.net", "/")
@@ -694,7 +701,8 @@ class TestBiomajFTPDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
 
   @attr('test')
@@ -871,7 +879,8 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
     # Test with wrong password
     ftpd = CurlDownload("ftps", "test.rebex.net", "/")
@@ -880,7 +889,8 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegex(cm.output, "^Error while listing")
+      # Test log message format (we assume that there is only 1 message)
+      self.assertRegex(cm.output[0], "Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -964,7 +974,8 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
         with self.assertLogs(logger="biomaj", level="ERROR") as cm:
             with self.assertRaises(Exception):
                 (file_list, dir_list) = rsyncd.list()
-                self.assertRegex(cm.output, "^Error while listing")
+            # Test log message format (we assume that there is only 1 message)
+            self.assertRegex(cm.output[0], "Error while listing")
 
     def test_rsync_match(self):
         rsyncd = RSYNCDownload(self.examples, "")

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -439,7 +439,7 @@ class TestBiomajSFTPDownload(unittest.TestCase):
 
   def setUp(self):
     self.utils = UtilsForTest()
-    # Temporary host key file in test dir (so this is claned)
+    # Temporary host key file in test dir (so this is cleaned)
     (_, self.khfile) = tempfile.mkstemp(dir=self.utils.test_dir)
 
   def tearDown(self):

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -781,7 +781,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
     ])
     ftpd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
                           wait_condition=tenacity.wait.wait_none()))
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         Exception, "^CurlDownload:Download:Error:",
         ftpd.download, self.utils.data_dir,
     )
@@ -793,7 +793,7 @@ class TestBiomajFTPDownload(unittest.TestCase):
           {'name': 'TITI.zip', 'year': '2016', 'month': '02', 'day': '19',
            'size': 1, 'save_as': 'TOTO1KB'}
     ])
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         Exception, "^CurlDownload:Download:Error:",
         ftpd.download, self.utils.data_dir,
     )
@@ -871,7 +871,7 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
     # Test with wrong password
     ftpd = CurlDownload("ftps", "test.rebex.net", "/")
@@ -880,7 +880,7 @@ class TestBiomajFTPSDownload(unittest.TestCase):
     with self.assertLogs(logger="biomaj", level="ERROR") as cm:
       with self.assertRaises(Exception):
         (file_list, dir_list) = ftpd.list()
-        self.assertRegexp(cm.output, "^Error while listing")
+        self.assertRegex(cm.output, "^Error while listing")
     ftpd.close()
 
   def test_download(self):
@@ -1028,7 +1028,7 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
         ])
         rsyncd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
                                 wait_condition=tenacity.wait.wait_none()))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Exception, "^RSYNCDownload:Download:Error:",
             rsyncd.download, self.utils.data_dir,
         )
@@ -1040,7 +1040,7 @@ class TestBiomajRSYNCDownload(unittest.TestCase):
               {'name': 'TITI.zip', 'year': '2016', 'month': '02', 'day': '19',
                'size': 1, 'save_as': 'TOTO1KB'}
         ])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Exception, "^RSYNCDownload:Download:Error:",
             rsyncd.download, self.utils.data_dir,
         )
@@ -1210,7 +1210,7 @@ class TestBiomajLocalIRODSDownload(unittest.TestCase):
         ])
         irodsd.set_options(dict(stop_condition=tenacity.stop.stop_after_attempt(n_attempts),
                                 wait_condition=tenacity.wait.wait_none()))
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Exception, "^IRODSDownload:Download:Error:",
             irodsd.download, self.utils.data_dir,
         )
@@ -1222,7 +1222,7 @@ class TestBiomajLocalIRODSDownload(unittest.TestCase):
               {'name': 'TITI.zip', 'year': '2016', 'month': '02', 'day': '19',
                'size': 1, 'save_as': 'TOTO1KB'}
         ])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             Exception, "^IRODSDownload:Download:Error:",
             irodsd.download, self.utils.data_dir,
         )

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -596,8 +596,6 @@ class TestBiomajDirectHTTPDownload(unittest.TestCase):
     """
     Test that errors in list are correctly caught.
     """
-    self.skipTest("skip as HEAD may not work in direct GET/POST")
-    return
     # Test access to non-existent directory
     file_list = ['/toto/debian/README.html']
     ftpd = DirectHTTPDownload('http', 'ftp2.fr.debian.org', '')

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -1240,3 +1240,27 @@ class TestBiomajLocalIRODSDownload(unittest.TestCase):
         self.assertTrue(len(irodsd.files_to_download) == 1)
         self.assertTrue(irodsd.retryer.statistics["attempt_number"] == n_attempts)
         irodsd.close()
+
+    def test_irods_list_error(self):
+        # Non-existing collection
+        irodsd = IRODSDownload(self.utils.SERVER, "fake_collection")
+        irodsd.set_param(dict(
+            user=self.utils.USER,
+            password=self.utils.PASSWORD,
+        ))
+        with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+            with self.assertRaises(Exception):
+                (file_list, dir_list) = irodsd.list()
+            # Test log message format (we assume that there is only 1 message)
+            self.assertRegex(cm.output[0], "Error while listing")
+        # Test with wrong password
+        irodsd = IRODSDownload(self.utils.SERVER, self.utils.COLLECTION)
+        irodsd.set_param(dict(
+            user=self.utils.USER,
+            password="badpassword",
+        ))
+        with self.assertLogs(logger="biomaj", level="ERROR") as cm:
+            with self.assertRaises(Exception):
+                (file_list, dir_list) = irodsd.list()
+            # Test log message format (we assume that there is only 1 message)
+            self.assertRegex(cm.output[0], "Error while listing")


### PR DESCRIPTION
This PR addresses some errors introduced by #30. There are 2 classes of errors.

First, direct downloaders were broken and I missed that:

- In some cases (particularly for `POST` resources) the remote server may not support `HEAD` and return `405` which makes `DirectHTTPDownload.list()` fail while we can simply ignore this error in this case.
- Similarly, the way we use `cURL` in `DirectFTPDownload.list()` leads to return code `350` which is OK but causes the method to fail.

Next, tests in PR #30 were flawed and therefore some errors were not detected. The main errors here are:

- `assertRegexp` no longer exists (it was replaced by `assertRegex`) but this was not detected because it was in `assertRaises` context. While at it, we don't use anymore the deprecated `assertRaisesRegexp` (the history of names in `unittest` can be found [here](https://docs.python.org/3/library/unittest.html#deprecated-aliases)).
- Use of `assertLogs` and the regex used in test were incorrect but this was not detected for the same reason.
- Errors in `RSYNCDownload.list()` were not correctly logged but it was detected.

Last but not least, `IRODSDownload` was not updated.

Status:

  - Errors due to flawed tests and in `RSYNCDownload` are corrected.
  - Regarding `DirectHTTPDownload.list()`, we explicitly consider `405` as a non-error in this case but we won't get metadata.
  - Regarding `DirectFTPDownload.list()`, we explicitely consider `350` a correct return code in this case.
  - `IRODSDownload.list()` now raises exceptions and log messages as other downloaders.