### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+- amd64
+- ppc64le
 language: python
 sudo: false
 python:


### PR DESCRIPTION
Adding power support ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3

The build is successful on both arch: amd64 & ppc64le, kindly refer the below link.,
https://travis-ci.com/github/santosh653/biomaj-download