### PR TITLE
Add PWD answer code

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -121,7 +121,7 @@ class CurlDownload(DownloadInterface):
         if self.curl_protocol in self.FTP_PROTOCOL_FAMILY:
             self.protocol_family = "ftp"
             self._parse_result = self._ftp_parse_result
-            self.ERRCODE_OK = [221, 226]
+            self.ERRCODE_OK = [221, 226, 257]
         elif self.curl_protocol in self.HTTP_PROTOCOL_FAMILY:
             self.protocol_family = "http"
             self._parse_result = self._http_parse_result


### PR DESCRIPTION
When trying to do directftp, we got the following error : 
```
2022-07-05 15:40:02,575 ERROR [root][MainThread] Error while listing ftp://xxxxx:xxxxx@dbnsfp.softgenetics.com/ - 257
2022-07-05 15:40:02,575 ERROR [root][MainThread] Error while listing ftp://xxxxx:xxxxx@dbnsfp.softgenetics.com/ - Error while listing ftp://dbnsfp:xxxxx@dbnsfp.softgenetics.com/ - 257                                                                                                                                                          
2022-07-05 15:40:02,575 INFO  [root][MainThread] Workflow:DownloadService:CleanSession
2022-07-05 15:40:02,575 ERROR [root][MainThread] Workflow:wf_release:Exception:Error while listing ftp://xxxxx:xxxxx@dbnsfp.softgenetics.com/ - 257
Traceback (most recent call last):
  File "/opt/biomaj/lib/python3.8/site-packages/biomaj/workflow.py", line 742, in wf_release
    (file_list, dir_list) = release_downloader.list()
  File "/opt/biomaj/lib/python3.8/site-packages/biomaj_download/download/direct.py", line 126, in list
    raise e
  File "/opt/biomaj/lib/python3.8/site-packages/biomaj_download/download/direct.py", line 122, in list
    raise Exception(msg)
Exception: Error while listing ftp://xxxx:xxxxxx@dbnsfp.softgenetics.com/ - 257
```
We add 257 as a good return code to permit listing and download.