### PR TITLE
remove dependency on old Mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mock
 pytest
 pycurl
 py-bcrypt

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ config = {
     ],
     'python_requires': '>=3.6, <4',
     'install_requires': requirements,
-    'tests_require': ['pytest', 'mock'],
+    'tests_require': ['pytest'],
     'packages': find_packages(),
     'include_package_data': True,
     'scripts': ['bin/biomaj_download_consumer.py'],

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -14,7 +14,7 @@ import logging
 import stat
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 
 from irods.session import iRODSSession
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.