### PR TITLE
make biomaj works with other locales

### DIFF
--- a/biomaj_download/download/rsync.py
+++ b/biomaj_download/download/rsync.py
@@ -134,7 +134,7 @@ class RSYNCDownload(DownloadInterface):
                 continue
             date = parts[2].split('/')
             rfile['permissions'] = parts[0]
-            rfile['size'] = int(parts[1].replace(',', ''))
+            rfile['size'] = int(parts[1].replace(',', '').replace('.', ''))
             rfile['month'] = int(date[1])
             rfile['day'] = int(date[2])
             rfile['year'] = int(date[0])


### PR DESCRIPTION
https://salsa.debian.org/med-team/biomaj3-download/-/pipelines/722719

biomaj currently fails with at least this locale:

LC_ALL=et_EE.UTF-8
LANGUAGE=et_EE.UTF-8:fr

a better fix would be to run "rsync" with the C.UTF-8 before attempting to parse it's output