### PR TITLE
Issue when 

### DIFF
--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -601,9 +601,16 @@ class CurlDownload(DownloadInterface):
                     rfile['month'] = today.month
                     rfile['day'] = today.day
                     rfile['year'] = today.year
-                rfile['name'] = foundfile[self.http_parse.file_name - 1]
-                filehash = (rfile['name'] + str(date) + str(rfile['size'])).encode('utf-8')
-                rfile['hash'] = hashlib.md5(filehash).hexdigest()
+                if isinstance(foundfile, tuple):
+                    rfile['name'] = foundfile[self.http_parse.file_name - 1]  
+                    filehash = (rfile['name'] + str(date) + str(rfile['size'])).encode('utf-8')
+                    rfile['hash'] = hashlib.md5(filehash).hexdigest()
+                else:
+                    #only self.http_parse.file_name is used
+                    rfile['name'] = foundfile
+                    filehash = (rfile['name'] + str(date) + str(rfile['size'])).encode('utf-8')
+                    rfile['hash'] = hashlib.md5(filehash).hexdigest()
+
                 rfiles.append(rfile)
         return (rfiles, rdirs)
 

--- a/biomaj_download/download/curl.py
+++ b/biomaj_download/download/curl.py
@@ -602,11 +602,11 @@ class CurlDownload(DownloadInterface):
                     rfile['day'] = today.day
                     rfile['year'] = today.year
                 if isinstance(foundfile, tuple):
-                    rfile['name'] = foundfile[self.http_parse.file_name - 1]  
+                    rfile['name'] = foundfile[self.http_parse.file_name - 1]
                     filehash = (rfile['name'] + str(date) + str(rfile['size'])).encode('utf-8')
                     rfile['hash'] = hashlib.md5(filehash).hexdigest()
                 else:
-                    #only self.http_parse.file_name is used
+                    # only self.http_parse.file_name is used
                     rfile['name'] = foundfile
                     filehash = (rfile['name'] + str(date) + str(rfile['size'])).encode('utf-8')
                     rfile['hash'] = hashlib.md5(filehash).hexdigest()


### PR DESCRIPTION
Hi,

I encountered an issue with the following configuration for the bank jaspar.elixir.no/download/data/2024/pfm:

```
http.group.file.name=1
http.group.file.size=-1
http.group.file.date=-1
```

Normally, the output of this code `files = re.findall(self.http_parse.file_line, result)` is a list of tuples. However, in my case, with only one matching pattern, it becomes just a list. 

Thus, with the old code the filename became M instead of MA089D.012.2.pfm 
https://github.com/genouest/biomaj-download/blob/b23668c6e474f7eb0428f827ec80e72aa80c63fd/biomaj_download/download/curl.py#L604


I created a small reproducer:

```
import re

# Example HTML content
html_content = '''
<li><a href="example4.pfm">MA089D.012.2.pfm</a></li>
'''
# Regular expression pattern
pattern = r'<li><a href=".*?">(MA089.*\.2\.pfm)</a>(</li>)'
# Find all matches
matches = re.findall(pattern, html_content)
print("Double pattern")
print(matches)

pattern = r'<li><a href=".*?">(MA089.*\.2\.pfm)</a></li>'
matches = re.findall(pattern, html_content)
print("Simple pattern")
print(matches)
```
The output will be:

```
double pattern
[('MA089D.012.2.pfm', '</li>')]
simple pattern
['MA089D.012.2.pfm']
```
So, to avoid this issue, I just check if it is a tuple, and if it's not, I assume that we only have the filename.

Best,
Brice